### PR TITLE
Replace `FocusRequester.requestFocusWithDelay()` by `rememberImmediateFocusRequester`

### DIFF
--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -60,6 +60,7 @@ dependencies {
   implementation(project(":ext:coroutines"))
   implementation(project(":platform:autos"))
   implementation(project(":platform:cache"))
+  implementation(project(":platform:focus"))
   implementation(project(":platform:starter"))
   implementation(project(":platform:ui"))
   implementation(libs.android.browser)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -28,19 +28,17 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -63,7 +61,7 @@ import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSiz
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.plus
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
-import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
+import com.jeanbarrossilva.orca.platform.focus.rememberImmediateFocusRequester
 
 /**
  * Screen that asks for the [Domain] to which the user belongs.
@@ -117,7 +115,7 @@ internal fun MastodonAuthorization(
   val isHeaderHidden by
     remember(lazyListState) { derivedStateOf { lazyListState.firstVisibleItemIndex > 0 } }
   val headerTitle = stringResource(R.string.core_http_authorization_account_origin)
-  val focusRequester = remember(::FocusRequester)
+  val focusRequester = rememberImmediateFocusRequester()
   val errorDispatcher = rememberErrorDispatcher {
     error(context, R.string.core_http_authorization_empty_domain, String::isBlank)
     error(context, R.string.core_http_authorization_invalid_domain) {
@@ -131,8 +129,6 @@ internal fun MastodonAuthorization(
       onSignIn()
     }
   }
-
-  LaunchedEffect(Unit) { focusRequester.requestFocusWithDelay() }
 
   Box(modifier) {
     Scaffold(
@@ -192,7 +188,7 @@ internal fun MastodonAuthorization(
         @OptIn(ExperimentalMaterial3Api::class)
         TopAppBar(title = { AutoSizeText(headerTitle) }, scrollBehavior = topAppBarScrollBehavior)
 
-        Divider()
+        HorizontalDivider()
       }
     }
   }

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -31,8 +31,8 @@ dependencies {
   api(project(":composite:composable"))
 
   implementation(project(":composite:timeline"))
+  implementation(project(":platform:focus"))
   implementation(project(":platform:starter"))
-  implementation(project(":platform:ui"))
   implementation(libs.android.compose.material.icons)
 
   testImplementation(libs.junit)

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -33,7 +33,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -41,7 +40,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -71,7 +69,7 @@ import com.jeanbarrossilva.orca.platform.autos.overlays.asPaddingValues
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.core.withSample
-import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
+import com.jeanbarrossilva.orca.platform.focus.rememberImmediateFocusRequester
 
 internal const val COMPOSER_FIELD = "composer-field"
 
@@ -102,7 +100,7 @@ private fun Composer(
   isToolbarInitiallyVisible: Boolean = false
 ) {
   val density = LocalDensity.current
-  val focusRequester = remember(::FocusRequester)
+  val focusRequester = rememberImmediateFocusRequester()
   val style = AutosTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Normal)
   val interactionSource = remember(::MutableInteractionSource)
   val brushColor = AutosTheme.colors.primary.container.asColor
@@ -112,8 +110,6 @@ private fun Composer(
   var toolbarSafeAreaPadding by remember { mutableStateOf(PaddingValues(end = 56.dp + 16.dp)) }
   val floatingActionButtonPosition =
     remember(isToolbarVisible) { if (isToolbarVisible) FabPosition.End else FabPosition.Center }
-
-  LaunchedEffect(Unit) { focusRequester.requestFocusWithDelay() }
 
   Scaffold(
     modifier,

--- a/feature/search/build.gradle.kts
+++ b/feature/search/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -32,8 +32,8 @@ dependencies {
   implementation(project(":composite:timeline"))
   implementation(project(":core:sample"))
   implementation(project(":platform:core"))
+  implementation(project(":platform:focus"))
   implementation(project(":platform:starter"))
-  implementation(project(":platform:ui"))
   implementation(project(":std:injector"))
   implementation(libs.loadable.list)
   implementation(libs.loadable.placeholder)

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -37,14 +37,11 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -60,7 +57,7 @@ import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.BackAction
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.core.sample
-import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
+import com.jeanbarrossilva.orca.platform.focus.rememberImmediateFocusRequester
 
 internal object SearchDefaults {
   val VerticalArrangement = Arrangement.Top
@@ -143,8 +140,7 @@ private fun Search(
           it,
           onClick = {
             onNavigateToProfileDetails(it.id)
-
-            @OptIn(ExperimentalComposeUiApi::class) softwareKeyboardController?.hide()
+            softwareKeyboardController?.hide()
           }
         )
       }
@@ -162,10 +158,8 @@ private fun Search(
   horizontalAlignment: Alignment.Horizontal = SearchDefaults.HorizontalAlignment,
   content: LazyListScope.() -> Unit
 ) {
-  val focusRequester = remember(::FocusRequester)
+  val focusRequester = rememberImmediateFocusRequester()
   val spacing = AutosTheme.spacings.medium.dp
-
-  LaunchedEffect(Unit) { focusRequester.requestFocusWithDelay() }
 
   Scaffold(
     modifier,

--- a/feature/settings/term-muting/build.gradle.kts
+++ b/feature/settings/term-muting/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -38,8 +38,9 @@ dependencies {
 
   ksp(project(":std:injector-processor"))
 
+  implementation(project(":core"))
   implementation(project(":platform:autos"))
+  implementation(project(":platform:focus"))
   implementation(project(":platform:starter"))
-  implementation(project(":platform:ui"))
   implementation(project(":std:injector"))
 }

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -26,13 +26,10 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
@@ -51,7 +48,7 @@ import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBarWit
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.plus
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
-import com.jeanbarrossilva.orca.platform.ui.core.requestFocusWithDelay
+import com.jeanbarrossilva.orca.platform.focus.rememberImmediateFocusRequester
 
 internal const val SETTINGS_TERM_MUTING_TEXT_FIELD_TAG = "settings-term-muting-text-field"
 internal const val SETTINGS_TERM_MUTING_MUTE_BUTTON = "settings-term-muting-mute-button"
@@ -86,7 +83,7 @@ internal fun TermMuting(
   val topAppBarScrollBehavior = TopAppBarDefaults.scrollBehavior
   val lazyListState = rememberLazyListState()
   val spacing = AutosTheme.spacings.medium.dp
-  val focusRequester = remember(::FocusRequester)
+  val focusRequester = rememberImmediateFocusRequester()
   val errorDispatcher = rememberErrorDispatcher {
     error(context, R.string.feature_settings_term_muting_empty_error, String::isBlank)
   }
@@ -98,8 +95,6 @@ internal fun TermMuting(
       onBackwardsNavigation()
     }
   }
-
-  LaunchedEffect(Unit) { focusRequester.requestFocusWithDelay() }
 
   DisposableEffect(term) {
     errorDispatcher.register(term)

--- a/platform/autos-test/build.gradle.kts
+++ b/platform/autos-test/build.gradle.kts
@@ -20,9 +20,17 @@ plugins {
   alias(libs.plugins.kotlin.android)
 }
 
-android.namespace = namespaceFor("platform.theme.test")
+android {
+  buildFeatures.compose = true
+  composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+  defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  namespace = namespaceFor("platform.autos.test")
+}
 
 dependencies {
+  androidTestImplementation(libs.android.compose.ui.test.manifest)
+  androidTestImplementation(libs.android.test.runner)
+
   implementation(project(":platform:autos"))
   implementation(libs.android.compose.ui.test.junit)
 }

--- a/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
+
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import org.junit.Rule
+import org.junit.Test
+
+internal class SemanticsNodeInteractionsProviderExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun findsTextField() {
+    composeRule
+      .apply { setContent { AutosTheme { TextField() } } }
+      .onTextField()
+      .assertIsDisplayed()
+  }
+
+  @Test
+  fun findsTextFieldErrors() {
+    composeRule
+      .apply {
+        setContent {
+          AutosTheme {
+            val errorDispatcher = rememberErrorDispatcher { errorAlways("💀") }
+
+            DisposableEffect(errorDispatcher) {
+              errorDispatcher.dispatch()
+              onDispose {}
+            }
+
+            TextField(errorDispatcher = errorDispatcher)
+          }
+        }
+      }
+      .onTextFieldErrors()
+      .assertIsDisplayed()
+  }
+}

--- a/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProvider.extensions.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2023 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.onNodeWithTag
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_ERRORS_TAG
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_TAG
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+
+/** [SemanticsNodeInteraction] of a [TextField]. */
+fun SemanticsNodeInteractionsProvider.onTextField(): SemanticsNodeInteraction {
+  return onNodeWithTag(TEXT_FIELD_TAG)
+}
+
+/** [SemanticsNodeInteraction] of a [TextField]'s errors. */
+fun SemanticsNodeInteractionsProvider.onTextFieldErrors(): SemanticsNodeInteraction {
+  return onNodeWithTag(TEXT_FIELD_ERRORS_TAG)
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -15,7 +15,7 @@
 
 package com.jeanbarrossilva.orca.platform.autos.kit.input.text
 
-import androidx.annotation.RestrictTo
+import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -57,8 +57,10 @@ import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErro
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 
+/** Tag that identifies a [TextField] for testing purposes. */
+const val TEXT_FIELD_TAG = "text-field"
+
 /** Tag that identifies a [TextField]'s errors' [Text] for testing purposes. */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 const val TEXT_FIELD_ERRORS_TAG = "text-field-errors"
 
 /** Default values used by a [TextField][_TextField]. */
@@ -86,9 +88,24 @@ object TextFieldDefaults {
 /**
  * Orca-specific [TextField].
  *
+ * @param modifier [Modifier] to be applied to the underlying [Column].
+ * @param errorDispatcher [ErrorDispatcher] to which invalid input state errors will be dispatched.
+ */
+@Composable
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+fun TextField(
+  modifier: Modifier = Modifier,
+  errorDispatcher: ErrorDispatcher = rememberErrorDispatcher()
+) {
+  _TextField(modifier, text = "", errorDispatcher)
+}
+
+/**
+ * Orca-specific [TextField].
+ *
  * @param text Text to be shown.
  * @param onTextChange Callback called whenever the text changes.
- * @param modifier [Modifier] to be applied to the underlying [TextField].
+ * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param errorDispatcher [ErrorDispatcher] by which invalid input state errors will be dispatched.
  * @param keyboardOptions Software-IME-specific options.
  * @param keyboardActions Software-IME-specific actions.
@@ -129,7 +146,8 @@ fun TextField(
             AutosTheme.borders.default.asBorderStroke.brush,
             shape
           )
-          .width(maxWidth),
+          .width(maxWidth)
+          .testTag(TEXT_FIELD_TAG),
         label = {
           val color =
             if (containsErrors) {
@@ -162,7 +180,7 @@ fun TextField(
 /**
  * Orca-specific [TextField].
  *
- * @param modifier [Modifier] to be applied to the underlying [TextField].
+ * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param text Text to be shown.
  * @param errorDispatcher [ErrorDispatcher] to which invalid input state errors will be dispatched.
  */

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/error/ErrorDispatcher.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/error/ErrorDispatcher.kt
@@ -95,7 +95,7 @@ class ErrorDispatcher private constructor(private val errors: List<Error>) {
      *
      * @param message [String] that describes the error.
      */
-    internal fun errorAlways(message: String) {
+    fun errorAlways(message: String) {
       error(message) { true }
     }
 

--- a/platform/focus/build.gradle.kts
+++ b/platform/focus/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,15 +13,22 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+}
 
-import androidx.compose.ui.test.SemanticsNodeInteraction
-import androidx.compose.ui.test.junit4.ComposeTestRule
-import androidx.compose.ui.test.onNodeWithTag
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_ERRORS_TAG
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+android {
+  buildFeatures.compose = true
+  composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+  defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+}
 
-/** [SemanticsNodeInteraction] of a [TextField]'s errors. */
-fun ComposeTestRule.onTextFieldErrors(): SemanticsNodeInteraction {
-  return onNodeWithTag(TEXT_FIELD_ERRORS_TAG)
+dependencies {
+  androidTestImplementation(project(":platform:autos"))
+  androidTestImplementation(project(":platform:autos-test"))
+  androidTestImplementation(libs.android.compose.ui.test.junit)
+  androidTestImplementation(libs.android.compose.ui.test.manifest)
+
+  api(libs.android.compose.ui)
 }

--- a/platform/focus/src/androidTest/java/com/jeanbarrossilva/orca/platform/focus/FocusRequesterExtensionsTests.kt
+++ b/platform/focus/src/androidTest/java/com/jeanbarrossilva/orca/platform/focus/FocusRequesterExtensionsTests.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.focus
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.test.kit.input.text.onTextField
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import org.junit.Rule
+import org.junit.Test
+
+internal class FocusRequesterExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun immediateFocusRequesterRequestsFocusImmediately() {
+    composeRule
+      .apply {
+        setContent {
+          AutosTheme { TextField(Modifier.focusRequester(rememberImmediateFocusRequester())) }
+        }
+      }
+      .run {
+        mainClock.advanceTimeBy(ImmediateFocusRequesterInitialDelay.inWholeMilliseconds)
+        onTextField().assertIsFocused()
+      }
+  }
+}

--- a/platform/focus/src/main/AndroidManifest.xml
+++ b/platform/focus/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright © 2024 Orca
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  ~ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with this program. If
+  ~ not, see https://www.gnu.org/licenses.
+  -->
+
+<manifest />

--- a/platform/focus/src/main/java/com/jeanbarrossilva/orca/platform/focus/FocusRequester.extensions.kt
+++ b/platform/focus/src/main/java/com/jeanbarrossilva/orca/platform/focus/FocusRequester.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,14 +13,30 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.ui.core
+package com.jeanbarrossilva.orca.platform.focus
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.focus.FocusRequester
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.delay
 
-/** Requests focus with an initial delay. */
-suspend fun FocusRequester.requestFocusWithDelay() {
-  delay(256.milliseconds)
-  requestFocus()
+/**
+ * [Duration] of the delay of an immediate [FocusRequester]'s initial focus.
+ *
+ * @see rememberImmediateFocusRequester
+ */
+internal val ImmediateFocusRequesterInitialDelay = 256.milliseconds
+
+/** Remembers a [FocusRequester] that automatically requests initial focus. */
+@Composable
+fun rememberImmediateFocusRequester(): FocusRequester {
+  return remember(::FocusRequester).also {
+    LaunchedEffect(it) {
+      delay(ImmediateFocusRequesterInitialDelay)
+      it.requestFocus()
+    }
+  }
 }

--- a/platform/ui/build.gradle.kts
+++ b/platform/ui/build.gradle.kts
@@ -18,11 +18,6 @@ plugins {
   alias(libs.plugins.kotlin.android)
 }
 
-android {
-  buildFeatures.compose = true
-  composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
-}
-
 dependencies {
   api(project(":core"))
   api(libs.android.compose.ui)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -52,6 +52,7 @@ include(
   ":platform:cache",
   ":platform:autos-test",
   ":platform:core",
+  ":platform:focus",
   ":platform:intents",
   ":platform:navigation",
   ":platform:navigation-test",


### PR DESCRIPTION
[`rememberImmediateFocusRequester`](https://github.com/orcaformastodon/android/blob/1f85ab131372e45150929eb97216ed5c78b70dc5/platform/focus/src/main/java/com/jeanbarrossilva/orca/platform/focus/FocusRequester.extensions.kt#L31) is at [`:platform:focus`](https://github.com/orcaformastodon/android/tree/1f85ab131372e45150929eb97216ed5c78b70dc5/platform/focus) instead of at [`:platform:ui`](https://github.com/orcaformastodon/android/tree/1f85ab131372e45150929eb97216ed5c78b70dc5/platform/ui).