### PR TITLE
Turn account username into a value class

### DIFF
--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/String.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/String.extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -24,5 +24,5 @@ import com.jeanbarrossilva.orca.core.instance.domain.Domain
  * @param domain Mastodon instance from which the user is.
  */
 infix fun String.at(domain: String): Account {
-  return Account(username = this, Domain(domain))
+  return Account(Username(this), Domain(domain))
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Username.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Username.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.feed.profile.account
+
+import com.jeanbarrossilva.orca.core.instance.domain.Domain
+
+/** Unique identifier of an [Account]. */
+@JvmInline
+value class Username
+@Throws(BlankValueException::class, IllegalValueException::class)
+internal constructor(internal val value: String) {
+  /** [IllegalArgumentException] thrown if the [value] is blank. */
+  class BlankValueException internal constructor() :
+    IllegalArgumentException("Username cannot be empty.")
+
+  /**
+   * [IllegalArgumentException] thrown if the [value] contains any illegal characters.
+   *
+   * @param illegalCharacters [Char]s that make the [value] illegal.
+   */
+  class IllegalValueException internal constructor(illegalCharacters: List<Char>) :
+    IllegalArgumentException("Username cannot contain: $illegalCharacters.")
+
+  init {
+    ensureNonBlankness()
+    ensureLegality()
+  }
+
+  override fun toString(): String {
+    return "@$value"
+  }
+
+  /**
+   * Ensures that the [value] isn't blank.
+   *
+   * @throws BlankValueException If the [value] is blank.
+   */
+  @Throws(BlankValueException::class)
+  private fun ensureNonBlankness() {
+    if (value.isBlank()) {
+      throw BlankValueException()
+    }
+  }
+
+  /**
+   * Ensures that the [value] is legal.
+   *
+   * @throws IllegalValueException If the [value] is illegal.
+   */
+  @Throws(IllegalValueException::class)
+  private fun ensureLegality() {
+    Domain.doOnIllegality(value) { throw IllegalValueException(it) }
+  }
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/AccountTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/AccountTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -19,7 +19,6 @@ import com.jeanbarrossilva.orca.core.instance.domain.Domain
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 
 internal class AccountTests {
   @Test
@@ -34,7 +33,7 @@ internal class AccountTests {
 
   @Test
   fun `GIVEN a string containing a username with illegal characters WHEN parsing it THEN it throws`() {
-    assertFailsWith<Account.IllegalUsernameException> { Account.of("john @appleseed.com") }
+    assertFailsWith<Username.IllegalValueException> { Account.of("john @appleseed.com") }
   }
 
   @Test
@@ -67,15 +66,5 @@ internal class AccountTests {
   @Test
   fun `GIVEN a string containing only a username with a valid fallback domain WHEN parsing it THEN it creates an account`() {
     assertEquals("john" at "appleseed.com", Account.of("john", fallbackDomain = "appleseed.com"))
-  }
-
-  @Test
-  fun `GIVEN a blank username WHEN verifying if it's valid THEN it isn't`() {
-    assertFalse(Account.isUsernameValid(" "))
-  }
-
-  @Test
-  fun `GIVEN a username with an illegal character WHEN verifying if it's valid THEN it isn't`() {
-    assertFalse(Account.isUsernameValid("john@"))
   }
 }

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/StringExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/account/StringExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,12 +22,12 @@ import kotlin.test.assertFailsWith
 internal class StringExtensionsTests {
   @Test
   fun `GIVEN a blank username WHEN creating an account with it THEN it throws`() {
-    assertFailsWith<Account.BlankUsernameException> { " " at "appleseed.com" }
+    assertFailsWith<Username.BlankValueException> { " " at "appleseed.com" }
   }
 
   @Test
   fun `GIVEN a username with an illegal character WHEN creating an account with it THEN it throws`() {
-    assertFailsWith<Account.IllegalUsernameException> { "john@" at "appleseed.com" }
+    assertFailsWith<Username.IllegalValueException> { "john@" at "appleseed.com" }
   }
 
   @Test


### PR DESCRIPTION
Changes the type of [`Account.username`](https://github.com/orcaformastodon/android/blob/b7b9e99c5ebfa7bb5bc1b2c8a1e366a26fdd8a41/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Account.kt#L31) from [`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string) to [`Username`](https://github.com/orcaformastodon/android/blob/b7b9e99c5ebfa7bb5bc1b2c8a1e366a26fdd8a41/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/account/Username.kt). Mainly done for exposing the string representation of a username with an "@" at the beginning at [`:core`](https://github.com/orcaformastodon/android/tree/b7b9e99c5ebfa7bb5bc1b2c8a1e366a26fdd8a41/core) instead of doing so at [`:platform:ui`](https://github.com/orcaformastodon/android/tree/b7b9e99c5ebfa7bb5bc1b2c8a1e366a26fdd8a41/platform/ui), which would facilitate the process of getting rid of that module (https://github.com/orgs/orcaformastodon/projects/1).