### PR TITLE
Test feed through its test module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
   "androidTestDemoImplementation"(project(":composite:timeline"))
   "androidTestDemoImplementation"(project(":composite:timeline-test"))
   "androidTestDemoImplementation"(project(":core:sample-test"))
+  "androidTestDemoImplementation"(project(":feature:feed-test"))
   "androidTestDemoImplementation"(project(":feature:gallery-test"))
   "androidTestDemoImplementation"(project(":platform:navigation-test"))
   "androidTestDemoImplementation"(project(":platform:testing"))

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/FeedTests.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
 import assertk.assertThat
 import com.jeanbarrossilva.orca.app.demo.test.assertContentDescriptionIsCohesiveToPagePosition
-import com.jeanbarrossilva.orca.app.demo.test.onSearchAction
 import com.jeanbarrossilva.orca.app.demo.test.perform
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithGalleryPreview
 import com.jeanbarrossilva.orca.app.demo.test.performScrollToPostPreviewWithLinkCard
@@ -40,6 +39,7 @@ import com.jeanbarrossilva.orca.ext.intents.intendStartingOf
 import com.jeanbarrossilva.orca.feature.composer.ComposerActivity
 import com.jeanbarrossilva.orca.feature.feed.FEED_FLOATING_ACTION_BUTTON_TAG
 import com.jeanbarrossilva.orca.feature.feed.FeedFragment
+import com.jeanbarrossilva.orca.feature.feed.test.onSearchAction
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
 import com.jeanbarrossilva.orca.feature.gallery.test.ui.onCloseActionButton
 import com.jeanbarrossilva.orca.feature.gallery.test.ui.onPager

--- a/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/app/src/androidTestDemo/java/com/jeanbarrossilva/orca/app/demo/test/SemanticsNodeInteractionsProvider.extensions.kt
@@ -19,8 +19,6 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionCollection
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
-import androidx.compose.ui.test.onNodeWithTag
-import com.jeanbarrossilva.orca.feature.feed.FEED_SEARCH_ACTION_TAG
 
 /**
  * Whether this [AssertionError] is the result of asserting the existence of a given
@@ -43,11 +41,6 @@ private val AssertionError.isBecauseIndexIsOutOfBounds
  * @see java.lang.AssertionError.isBecauseIndexIsOutOfBounds
  */
 private object END
-
-/** [SemanticsNodeInteraction] of a feed's search action. */
-internal fun SemanticsNodeInteractionsProvider.onSearchAction(): SemanticsNodeInteraction {
-  return onNodeWithTag(FEED_SEARCH_ACTION_TAG)
-}
 
 /**
  * Performs the given [action] on each of the provided [SemanticsNodeInteraction]s.

--- a/feature/feed-test/build.gradle.kts
+++ b/feature/feed-test/build.gradle.kts
@@ -1,0 +1,37 @@
+import com.jeanbarrossilva.orca.namespaceFor
+
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+plugins {
+  alias(libs.plugins.android.library)
+  alias(libs.plugins.kotlin.android)
+}
+
+android {
+  buildFeatures.compose = true
+  composeOptions.kotlinCompilerExtensionVersion = libs.versions.android.compose.compiler.get()
+  defaultConfig.testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+  namespace = namespaceFor("feature.feed.test")
+}
+
+dependencies {
+  androidTestImplementation(libs.android.compose.ui.test.manifest)
+  androidTestImplementation(libs.android.test.runner)
+
+  implementation(project(":feature:feed"))
+  implementation(project(":platform:autos"))
+  implementation(libs.android.compose.ui.test.junit)
+}

--- a/feature/feed-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/feature/feed-test/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -13,19 +13,20 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.app.demo
+package com.jeanbarrossilva.orca.feature.feed.test
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import com.jeanbarrossilva.orca.app.demo.test.onSearchAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.feature.feed.Feed
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test
 
 internal class SemanticsNodeInteractionsProviderExtensionsTests {
-  @get:Rule val composeRule = createAndroidComposeRule<DemoOrcaActivity>()
+  @get:Rule val composeRule = createComposeRule()
 
   @Test
   fun findsSearchAction() {
-    composeRule.onSearchAction().assertIsDisplayed()
+    composeRule.apply { setContent { AutosTheme { Feed() } } }.onSearchAction().assertIsDisplayed()
   }
 }

--- a/feature/feed-test/src/main/AndroidManifest.xml
+++ b/feature/feed-test/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright © 2024 Orca
+  ~
+  ~ This program is free software: you can redistribute it and/or modify it under the terms of the
+  ~ GNU General Public License as published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+  ~ even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License along with this program. If
+  ~ not, see https://www.gnu.org/licenses.
+  -->
+
+<manifest />

--- a/feature/feed-test/src/main/java/com/jeanbarrossilva/orca/feature/feed/test/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/feature/feed-test/src/main/java/com/jeanbarrossilva/orca/feature/feed/test/SemanticsNodeInteractionsProvider.extensions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.feature.feed.test
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import androidx.compose.ui.test.onNodeWithTag
+import com.jeanbarrossilva.orca.feature.feed.FEED_SEARCH_ACTION_TAG
+import com.jeanbarrossilva.orca.feature.feed.Feed
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBar
+
+/** [SemanticsNodeInteraction] of a [Feed]'s [TopAppBar] search action. */
+fun SemanticsNodeInteractionsProvider.onSearchAction(): SemanticsNodeInteraction {
+  return onNodeWithTag(FEED_SEARCH_ACTION_TAG)
+}

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,6 +15,7 @@
 
 package com.jeanbarrossilva.orca.feature.feed
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -51,6 +52,12 @@ import java.net.URL
 
 const val FEED_SEARCH_ACTION_TAG = "feed-search-action-tag"
 const val FEED_FLOATING_ACTION_BUTTON_TAG = "feed-floating-action-button"
+
+@Composable
+@VisibleForTesting
+fun Feed(modifier: Modifier = Modifier) {
+  Feed(PostPreview.samples.toSerializableList().toListLoadable(), modifier)
+}
 
 @Composable
 internal fun Feed(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,7 @@ include(
   ":ext:testing",
   ":feature:composer",
   ":feature:feed",
+  ":feature:feed-test",
   ":feature:gallery",
   ":feature:gallery-test",
   ":feature:post-details",


### PR DESCRIPTION
Adds [`:feature:feed-test`](https://github.com/orcaformastodon/android/tree/0c4107e9f1b51f50f1be1f80ff22afcb0adca4aa/feature/feed-test) and replaces test interactions with the feed's search action done directly through its tag by calls to [`SemanticsNodeInteractionsProvider.onSearchAction()`](https://github.com/orcaformastodon/android/blob/0c4107e9f1b51f50f1be1f80ff22afcb0adca4aa/feature/feed-test/src/main/java/com/jeanbarrossilva/orca/feature/feed/test/SemanticsNodeInteractionsProvider.extensions.kt#L26).