### PR TITLE
Split text field types into two within `:platform:autos`

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
@@ -50,7 +50,7 @@ import com.jeanbarrossilva.orca.core.mastodon.R
 import com.jeanbarrossilva.orca.core.mastodon.auth.authorization.viewmodel.MastodonAuthorizationViewModel
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.PrimaryButton
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.SecondaryButton
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.containsErrorsAsState
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold
@@ -92,7 +92,7 @@ internal fun MastodonAuthorization(
  * Screen that asks for the [Domain] to which the user belongs.
  *
  * @param domain [String] version of the [Domain].
- * @param onDomainChange Callback run whenever the user inputs to the domain [TextField].
+ * @param onDomainChange Callback run whenever the user inputs to the domain [FormTextField].
  * @param onSignIn Callback run whenever the sign-in [PrimaryButton] is clicked.
  * @param onHelp Action to be performed when help is requested.
  * @param modifier [Modifier] to be applied to the underlying [Box].
@@ -134,7 +134,7 @@ internal fun MastodonAuthorization(
     Scaffold(
       buttonBar = {
         Column(verticalArrangement = Arrangement.spacedBy(ButtonBarDefaults.spacing)) {
-          TextField(
+          FormTextField(
             domain,
             onDomainChange,
             Modifier.focusRequester(focusRequester)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
@@ -143,7 +143,7 @@ internal fun MastodonAuthorization(
             errorDispatcher,
             KeyboardOptions(imeAction = ImeAction.Go),
             KeyboardActions(onGo = { onDone() }),
-            isSingleLined = true
+            isSinglyLined = true
           ) {
             Text(stringResource(R.string.core_http_authorization_domain))
           }

--- a/feature/composer/build.gradle.kts
+++ b/feature/composer/build.gradle.kts
@@ -25,6 +25,7 @@ android {
 }
 
 dependencies {
+  androidTestImplementation(project(":platform:autos-test"))
   androidTestImplementation(libs.android.compose.ui.test.junit)
   androidTestImplementation(libs.android.test.runner)
 

--- a/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/ComposerActivityTests.kt
+++ b/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/ComposerActivityTests.kt
@@ -31,8 +31,8 @@ import androidx.compose.ui.text.withStyle
 import com.jeanbarrossilva.orca.feature.composer.test.assertTextEquals
 import com.jeanbarrossilva.orca.feature.composer.test.isBoldFormat
 import com.jeanbarrossilva.orca.feature.composer.test.isItalicFormat
-import com.jeanbarrossilva.orca.feature.composer.test.onField
 import com.jeanbarrossilva.orca.feature.composer.test.onToolbar
+import com.jeanbarrossilva.orca.platform.autos.test.kit.input.text.onTextField
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -43,11 +43,11 @@ internal class ComposerActivityTests {
 
   @Test
   fun stylesSelectedComposition() {
-    composeRule.onField().performTextInput("Hello, world!")
-    composeRule.onField().performTextInputSelection(TextRange(0, 5))
+    composeRule.onTextField().performTextInput("Hello, world!")
+    composeRule.onTextField().performTextInputSelection(TextRange(0, 5))
     composeRule.onToolbar().onChildren().filterToOne(isBoldFormat()).performClick()
     composeRule
-      .onField()
+      .onTextField()
       .assertTextEquals(
         buildAnnotatedString {
           withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append("Hello") }
@@ -62,12 +62,12 @@ internal class ComposerActivityTests {
   )
   @Test
   fun keepsStylizationWhenUnselectingStylizedComposition() {
-    composeRule.onField().performTextInput("Hello, world!")
-    composeRule.onField().performTextInputSelection(TextRange(7, 12))
+    composeRule.onTextField().performTextInput("Hello, world!")
+    composeRule.onTextField().performTextInputSelection(TextRange(7, 12))
     composeRule.onToolbar().onChildren().filterToOne(isItalicFormat()).performClick()
-    repeat(64) { composeRule.onField().performTextInputSelection(TextRange((0..12).random())) }
+    repeat(64) { composeRule.onTextField().performTextInputSelection(TextRange((0..12).random())) }
     composeRule
-      .onField()
+      .onTextField()
       .assertTextEquals(
         buildAnnotatedString {
           append("Hello, ")

--- a/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/ComposeTestRule.extensions.kt
+++ b/feature/composer/src/androidTest/java/com/jeanbarrossilva/orca/feature/composer/test/ComposeTestRule.extensions.kt
@@ -18,15 +18,8 @@ package com.jeanbarrossilva.orca.feature.composer.test
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
-import com.jeanbarrossilva.orca.feature.composer.COMPOSER_FIELD
-import com.jeanbarrossilva.orca.feature.composer.Composer
 import com.jeanbarrossilva.orca.feature.composer.ui.COMPOSER_TOOLBAR
 import com.jeanbarrossilva.orca.feature.composer.ui.Toolbar
-
-/** [SemanticsNodeInteraction] of a [Composer]'s field. */
-internal fun ComposeTestRule.onField(): SemanticsNodeInteraction {
-  return onNodeWithTag(COMPOSER_FIELD)
-}
 
 /** [SemanticsNodeInteraction] of a [Toolbar]. */
 internal fun ComposeTestRule.onToolbar(): SemanticsNodeInteraction {

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
@@ -19,19 +19,16 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FabPosition
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -42,25 +39,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.orca.composite.timeline.avatar.SmallAvatar
 import com.jeanbarrossilva.orca.composite.timeline.text.toAnnotatedString
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts
 import com.jeanbarrossilva.orca.feature.composer.ui.Toolbar
-import com.jeanbarrossilva.orca.platform.autos.colors.asColor
 import com.jeanbarrossilva.orca.platform.autos.iconography.asImageVector
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.icon.HoverableIconButton
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextFieldDefaults as _TextFieldDefaults
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.CompositionTextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextFieldDefaults
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBar
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
@@ -70,8 +63,6 @@ import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.core.withSample
 import com.jeanbarrossilva.orca.platform.focus.rememberImmediateFocusRequester
-
-internal const val COMPOSER_FIELD = "composer-field"
 
 @Composable
 internal fun Composer(
@@ -101,10 +92,6 @@ private fun Composer(
 ) {
   val density = LocalDensity.current
   val focusRequester = rememberImmediateFocusRequester()
-  val style = AutosTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Normal)
-  val interactionSource = remember(::MutableInteractionSource)
-  val brushColor = AutosTheme.colors.primary.container.asColor
-  val cursorBrush = remember(brushColor) { SolidColor(brushColor) }
   var isToolbarVisible by remember { mutableStateOf(isToolbarInitiallyVisible) }
   val toolbarSpacing = AutosTheme.spacings.medium.dp
   var toolbarSafeAreaPadding by remember { mutableStateOf(PaddingValues(end = 56.dp + 16.dp)) }
@@ -150,36 +137,19 @@ private fun Composer(
     Box(Modifier.padding(padding).fillMaxSize()) {
       LazyColumn(
         contentPadding =
-          PaddingValues(AutosTheme.spacings.large.dp) + AutosTheme.overlays.fab.asPaddingValues
+          PaddingValues(bottom = TextFieldDefaults.compositionSpacing) +
+            AutosTheme.overlays.fab.asPaddingValues
       ) {
         item {
-          BasicTextField(
+          CompositionTextField(
             value,
             onValueChange,
+            leadingIcon = { SmallAvatar() },
+            onSend = onCompose,
             Modifier.onFocusChanged { isToolbarVisible = it.isFocused }
               .focusRequester(focusRequester)
-              .testTag(COMPOSER_FIELD),
-            textStyle = style,
-            interactionSource = interactionSource,
-            cursorBrush = cursorBrush
-          ) { innerTextField ->
-            @OptIn(ExperimentalMaterial3Api::class)
-            TextFieldDefaults.DecorationBox(
-              value.text,
-              innerTextField,
-              enabled = true,
-              singleLine = false,
-              VisualTransformation.None,
-              interactionSource,
-              placeholder = {
-                Text(
-                  stringResource(R.string.feature_composer_placeholder),
-                  style = style.copy(color = AutosTheme.colors.tertiary.asColor)
-                )
-              },
-              colors = _TextFieldDefaults.colors(containerColor = Color.Transparent),
-              contentPadding = PaddingValues(0.dp)
-            )
+          ) {
+            Text(stringResource(R.string.feature_composer_placeholder))
           }
         }
       }

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
@@ -51,7 +51,7 @@ import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearchResult
 import com.jeanbarrossilva.orca.feature.search.ui.SearchResultCard
 import com.jeanbarrossilva.orca.platform.autos.colors.asColor
 import com.jeanbarrossilva.orca.platform.autos.iconography.asImageVector
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.BackAction
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
@@ -174,7 +174,11 @@ private fun Search(
           BackAction(onClick = onBackwardsNavigation)
         }
 
-        TextField(query, onQueryChange, Modifier.focusRequester(focusRequester).fillMaxWidth()) {
+        FormTextField(
+          query,
+          onQueryChange,
+          Modifier.focusRequester(focusRequester).fillMaxWidth()
+        ) {
           Text(stringResource(R.string.feature_search_placeholder))
         }
       }

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.orca.platform.autos.kit.action.button.PrimaryButton
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.containsErrorsAsState
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold
@@ -126,7 +126,7 @@ internal fun TermMuting(
       contentPadding = it + PaddingValues(spacing)
     ) {
       item {
-        TextField(
+        FormTextField(
           term,
           onTermChange,
           Modifier.focusRequester(focusRequester)

--- a/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -18,7 +18,7 @@ package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
@@ -28,15 +28,15 @@ internal class SemanticsNodeInteractionsProviderExtensionsTests {
   @get:Rule val composeRule = createComposeRule()
 
   @Test
-  fun findsTextField() {
+  fun findsFormTextField() {
     composeRule
-      .apply { setContent { AutosTheme { TextField() } } }
+      .apply { setContent { AutosTheme { FormTextField() } } }
       .onTextField()
       .assertIsDisplayed()
   }
 
   @Test
-  fun findsTextFieldErrors() {
+  fun findsFormTextFieldErrors() {
     composeRule
       .apply {
         setContent {
@@ -48,7 +48,7 @@ internal class SemanticsNodeInteractionsProviderExtensionsTests {
               onDispose {}
             }
 
-            TextField(errorDispatcher = errorDispatcher)
+            FormTextField(errorDispatcher = errorDispatcher)
           }
         }
       }

--- a/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.CompositionTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
@@ -28,10 +29,39 @@ internal class SemanticsNodeInteractionsProviderExtensionsTests {
   @get:Rule val composeRule = createComposeRule()
 
   @Test
+  fun findsCompositionTextField() {
+    composeRule
+      .apply { setContent { AutosTheme { CompositionTextField() } } }
+      .onTextField()
+      .assertIsDisplayed()
+  }
+
+  @Test
   fun findsFormTextField() {
     composeRule
       .apply { setContent { AutosTheme { FormTextField() } } }
       .onTextField()
+      .assertIsDisplayed()
+  }
+
+  @Test
+  fun findsCompositionTextFieldErrors() {
+    composeRule
+      .apply {
+        setContent {
+          AutosTheme {
+            val errorDispatcher = rememberErrorDispatcher { errorAlways("☠️") }
+
+            DisposableEffect(errorDispatcher) {
+              errorDispatcher.dispatch()
+              onDispose {}
+            }
+
+            CompositionTextField(errorDispatcher = errorDispatcher)
+          }
+        }
+      }
+      .onTextFieldErrors()
       .assertIsDisplayed()
   }
 

--- a/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProvider.extensions.kt
@@ -18,16 +18,27 @@ package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.onNodeWithTag
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.CompositionTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_ERRORS_TAG
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_TAG
 
-/** [SemanticsNodeInteraction] of a [FormTextField]. */
+/**
+ * [SemanticsNodeInteraction] of a text field.
+ *
+ * @see CompositionTextField
+ * @see FormTextField
+ */
 fun SemanticsNodeInteractionsProvider.onTextField(): SemanticsNodeInteraction {
   return onNodeWithTag(TEXT_FIELD_TAG)
 }
 
-/** [SemanticsNodeInteraction] of a [FormTextField]'s errors. */
+/**
+ * [SemanticsNodeInteraction] of a text field's errors.
+ *
+ * @see CompositionTextField
+ * @see FormTextField
+ */
 fun SemanticsNodeInteractionsProvider.onTextFieldErrors(): SemanticsNodeInteraction {
   return onNodeWithTag(TEXT_FIELD_ERRORS_TAG)
 }

--- a/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/input/text/SemanticsNodeInteractionsProvider.extensions.kt
@@ -18,16 +18,16 @@ package com.jeanbarrossilva.orca.platform.autos.test.kit.input.text
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
 import androidx.compose.ui.test.onNodeWithTag
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_ERRORS_TAG
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TEXT_FIELD_TAG
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
 
-/** [SemanticsNodeInteraction] of a [TextField]. */
+/** [SemanticsNodeInteraction] of a [FormTextField]. */
 fun SemanticsNodeInteractionsProvider.onTextField(): SemanticsNodeInteraction {
   return onNodeWithTag(TEXT_FIELD_TAG)
 }
 
-/** [SemanticsNodeInteraction] of a [TextField]'s errors. */
+/** [SemanticsNodeInteraction] of a [FormTextField]'s errors. */
 fun SemanticsNodeInteractionsProvider.onTextFieldErrors(): SemanticsNodeInteraction {
   return onNodeWithTag(TEXT_FIELD_ERRORS_TAG)
 }

--- a/platform/autos/build.gradle.kts
+++ b/platform/autos/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
   api(libs.android.compose.ui.tooling)
   api(libs.autos)
 
-  implementation(kotlin("stdlib"))
+  implementation(project(":ext:reflection"))
   implementation(libs.accompanist.adapter)
   implementation(libs.android.material)
   implementation(libs.kotlin.reflect)

--- a/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextFieldTests.kt
+++ b/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextFieldTests.kt
@@ -31,7 +31,7 @@ internal class TextFieldTests {
   fun showsErrorsWhenTextIsInvalid() {
     val errorDispatcher =
       buildErrorDispatcher { errorAlways("🫵🏽") }.apply(ErrorDispatcher::dispatch)
-    composeRule.setContent { AutosTheme { TextField(errorDispatcher = errorDispatcher) } }
+    composeRule.setContent { AutosTheme { FormTextField(errorDispatcher = errorDispatcher) } }
     composeRule.onTextFieldErrors().assertIsDisplayed()
   }
 }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -315,13 +315,12 @@ private fun ContentWithErrors(
       context.getString(R.string.platform_ui_text_field_consecutive_error_message, it)
     }
   val containsErrors by errorDispatcher.containsErrorsAsState
-  val secondaryTextColor =
+  val errorMessagesColor =
     if (containsErrors) {
       AutosTheme.colors.error.container.asColor
     } else {
       LocalContentColor.current
     }
-  val secondaryTextStyle = LocalTextStyle.current.copy(color = secondaryTextColor)
 
   DisposableEffect(text) {
     errorDispatcher.register(text)
@@ -329,13 +328,18 @@ private fun ContentWithErrors(
   }
 
   Column(modifier, Arrangement.spacedBy(AutosTheme.spacings.medium.dp)) {
-    BoxWithConstraints { content(containsErrors, secondaryTextStyle) }
+    BoxWithConstraints {
+      content(
+        containsErrors,
+        LocalTextStyle.current.copy(color = AutosTheme.colors.tertiary.asColor)
+      )
+    }
 
     AnimatedVisibility(visible = containsErrors) {
       Text(
         errorMessages,
         Modifier.padding(start = errorMessagesStartSpacing).testTag(TEXT_FIELD_ERRORS_TAG),
-        secondaryTextColor
+        errorMessagesColor
       )
     }
   }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -47,26 +47,28 @@ import com.jeanbarrossilva.orca.platform.autos.R
 import com.jeanbarrossilva.orca.platform.autos.borders.asBorderStroke
 import com.jeanbarrossilva.orca.platform.autos.colors.asColor
 import com.jeanbarrossilva.orca.platform.autos.forms.asShape
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField as _TextField
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextFieldDefaults as _TextFieldDefaults
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.ErrorDispatcher
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.buildErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.containsErrorsAsState
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.messages
 import com.jeanbarrossilva.orca.platform.autos.kit.input.text.error.rememberErrorDispatcher
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 
-/** Tag that identifies a [TextField] for testing purposes. */
+/**
+ * Tag that identifies a text field for testing purposes.
+ *
+ * @see FormTextField
+ */
 const val TEXT_FIELD_TAG = "text-field"
 
-/** Tag that identifies a [TextField]'s errors' [Text] for testing purposes. */
+/** Tag that identifies a text field's errors' [Text] for testing purposes. */
 const val TEXT_FIELD_ERRORS_TAG = "text-field-errors"
 
-/** Default values used by a [TextField][_TextField]. */
+/** Default values used by Orca's text fields. */
 object TextFieldDefaults {
   /**
-   * [TextFieldColors] by which a [TextField][_TextField] is colored by default.
+   * [TextFieldColors] by which a [TextField][FormTextField] is colored by default.
    *
    * @param containerColor [Color] to color the container with.
    */
@@ -93,15 +95,15 @@ object TextFieldDefaults {
  */
 @Composable
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-fun TextField(
+fun FormTextField(
   modifier: Modifier = Modifier,
   errorDispatcher: ErrorDispatcher = rememberErrorDispatcher()
 ) {
-  _TextField(modifier, text = "", errorDispatcher)
+  FormTextField(modifier, text = "", errorDispatcher)
 }
 
 /**
- * Orca-specific [TextField].
+ * Orca-specific text field for forms.
  *
  * @param text Text to be shown.
  * @param onTextChange Callback called whenever the text changes.
@@ -112,7 +114,7 @@ fun TextField(
  * @param isSingleLined Whether there can be multiple lines.
  */
 @Composable
-fun TextField(
+fun FormTextField(
   text: String,
   onTextChange: (text: String) -> Unit,
   modifier: Modifier = Modifier,
@@ -178,36 +180,36 @@ fun TextField(
 }
 
 /**
- * Orca-specific [TextField].
+ * Orca-specific text field for forms.
  *
  * @param modifier [Modifier] to be applied to the underlying [Column].
  * @param text Text to be shown.
  * @param errorDispatcher [ErrorDispatcher] to which invalid input state errors will be dispatched.
  */
 @Composable
-internal fun TextField(
+internal fun FormTextField(
   modifier: Modifier = Modifier,
   text: String = "Text",
   errorDispatcher: ErrorDispatcher = rememberErrorDispatcher()
 ) {
-  _TextField(text, onTextChange = {}, modifier, errorDispatcher) { Text("Label") }
+  FormTextField(text, onTextChange = {}, modifier, errorDispatcher) { Text("Label") }
 }
 
-/** Preview of a focused [TextField][_TextField]. */
+/** Preview of a focused [FormTextField]. */
 @Composable
 @MultiThemePreview
-private fun ValidTextFieldPreview() {
-  AutosTheme { _TextField() }
+private fun ValidFormTextFieldPreview() {
+  AutosTheme { FormTextField() }
 }
 
-/** Preview of a [TextField] with errors. */
+/** Preview of a [FormTextField] with errors. */
 @Composable
 @MultiThemePreview
-private fun InvalidTextFieldPreview() {
+private fun InvalidFormTextFieldPreview() {
   AutosTheme {
-    _TextField(
+    FormTextField(
       errorDispatcher =
-        buildErrorDispatcher {
+        rememberErrorDispatcher {
             errorAlways("This is an error.")
             errorAlways("This is another error. 😛")
           }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -230,7 +230,7 @@ fun CompositionTextField(
  * @param errorDispatcher [ErrorDispatcher] by which invalid input state errors will be dispatched.
  * @param keyboardOptions Software-IME-specific options.
  * @param keyboardActions Software-IME-specific actions.
- * @param isSingleLined Whether there can be multiple lines.
+ * @param isSinglyLined Whether there can be only one line.
  */
 @Composable
 fun FormTextField(
@@ -240,7 +240,7 @@ fun FormTextField(
   errorDispatcher: ErrorDispatcher = rememberErrorDispatcher(),
   keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
   keyboardActions: KeyboardActions = KeyboardActions.Default,
-  isSingleLined: Boolean = false,
+  isSinglyLined: Boolean = false,
   label: @Composable () -> Unit
 ) {
   val form = AutosTheme.forms.large as Form.PerCorner
@@ -266,7 +266,7 @@ fun FormTextField(
       isError = containsErrors,
       keyboardOptions = keyboardOptions,
       keyboardActions = keyboardActions,
-      singleLine = isSingleLined,
+      singleLine = isSinglyLined,
       shape = shape,
       colors = _TextFieldDefaults.colors()
     )

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.platform.autos.kit.input.text
 
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -43,7 +44,9 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -155,6 +158,7 @@ fun FormTextField(
  * @param onSend Action performed when the [value] is requested to be sent.
  * @param modifier [Modifier] to be applied to the underlying [ContentWithErrors].
  * @param errorDispatcher [ErrorDispatcher] by which invalid input state errors will be dispatched.
+ * @param colors [TextFieldColors] by which it its colored.
  * @param placeholder [Text] to be shown when the [CompositionTextField] is focused and the [value]
  *   is empty.
  */
@@ -166,6 +170,7 @@ fun CompositionTextField(
   onSend: () -> Unit,
   modifier: Modifier = Modifier,
   errorDispatcher: ErrorDispatcher = rememberErrorDispatcher(),
+  colors: TextFieldColors = _TextFieldDefaults.colors(),
   placeholder: @Composable () -> Unit = {}
 ) {
   val interactionSource = remember(::MutableInteractionSource)
@@ -177,6 +182,7 @@ fun CompositionTextField(
   }
 
   val style = LocalTextStyle.current
+  var containerColor by remember(colors) { mutableStateOf(Color.Unspecified) }
   val cursorBrushColor = AutosTheme.colors.primary.container.asColor
   val cursorBrush = remember(cursorBrushColor) { SolidColor(cursorBrushColor) }
   val spacing = _TextFieldDefaults.compositionSpacing
@@ -185,8 +191,11 @@ fun CompositionTextField(
     value.text,
     errorDispatcher,
     errorMessagesStartSpacing = spacing,
-    modifier.padding(bottom = spacing)
-  ) { _, secondaryTextStyle ->
+    modifier.background(containerColor).padding(bottom = spacing)
+  ) { containsErrors, secondaryTextStyle ->
+    containerColor =
+      colors.containerColor(isEnabled = true, containsErrors, interactionSource).value
+
     BasicTextField(
       value,
       onValueChange,
@@ -207,7 +216,7 @@ fun CompositionTextField(
         interactionSource,
         placeholder = { ProvideTextStyle(secondaryTextStyle) { placeholder() } },
         leadingIcon = leadingIcon,
-        colors = _TextFieldDefaults.colors(containerColor = Color.Transparent),
+        colors = colors,
         contentPadding = PaddingValues(start = spacing * 2)
       )
     }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt
@@ -24,8 +24,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -207,15 +205,10 @@ fun CompositionTextField(
         singleLine = false,
         VisualTransformation.None,
         interactionSource,
-        placeholder = {
-          Row {
-            Spacer(Modifier.width(spacing))
-            ProvideTextStyle(secondaryTextStyle) { placeholder() }
-          }
-        },
+        placeholder = { ProvideTextStyle(secondaryTextStyle) { placeholder() } },
         leadingIcon = leadingIcon,
         colors = _TextFieldDefaults.colors(containerColor = Color.Transparent),
-        contentPadding = PaddingValues(0.dp)
+        contentPadding = PaddingValues(start = spacing * 2)
       )
     }
   }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextFieldColors.extensions.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextFieldColors.extensions.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.input.text
+
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.currentComposer
+import androidx.compose.runtime.currentCompositeKeyHash
+import androidx.compose.ui.graphics.Color
+import com.jeanbarrossilva.orca.ext.reflection.access
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.declaredMemberFunctions
+
+/**
+ * Color by which the container of a text field should be colored.
+ *
+ * @param isEnabled Whether the text field is enabled.
+ * @param isInvalid Whether the text field is in an invalid state.
+ * @param interactionSource [InteractionSource] to which [Interaction]s with the text field are
+ *   sent.
+ * @throws NoSuchMethodException If, because this uses reflection under the hood, the method that
+ *   returns the [State] by which the container [Color] is held is not found.
+ */
+@Composable
+@Throws(NoSuchMethodException::class)
+internal fun TextFieldColors.containerColor(
+  isEnabled: Boolean,
+  isInvalid: Boolean,
+  interactionSource: InteractionSource
+): State<Color> {
+  val composer = currentComposer
+  val key = currentCompositeKeyHash
+  return try {
+    TextFieldColors::class
+      .declaredMemberFunctions
+      .filterIsInstance<KFunction<State<Color>>>()
+      .single { it.name.startsWith("containerColor") }
+      .access { call(this@containerColor, isEnabled, isInvalid, interactionSource, composer, key) }
+  } catch (_: NoSuchElementException) {
+    throw NoSuchMethodException(
+      "TextFieldColors.containerColor(Boolean, Boolean, InteractionSource, Composer, Int): " +
+        "State<Color>"
+    )
+  }
+}

--- a/platform/focus/src/androidTest/java/com/jeanbarrossilva/orca/platform/focus/FocusRequesterExtensionsTests.kt
+++ b/platform/focus/src/androidTest/java/com/jeanbarrossilva/orca/platform/focus/FocusRequesterExtensionsTests.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
-import com.jeanbarrossilva.orca.platform.autos.kit.input.text.TextField
+import com.jeanbarrossilva.orca.platform.autos.kit.input.text.FormTextField
 import com.jeanbarrossilva.orca.platform.autos.test.kit.input.text.onTextField
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
@@ -33,7 +33,7 @@ internal class FocusRequesterExtensionsTests {
     composeRule
       .apply {
         setContent {
-          AutosTheme { TextField(Modifier.focusRequester(rememberImmediateFocusRequester())) }
+          AutosTheme { FormTextField(Modifier.focusRequester(rememberImmediateFocusRequester())) }
         }
       }
       .run {


### PR DESCRIPTION
Adds, alongside the existing [`FormTextField`](https://github.com/orcaformastodon/android/blob/1dbf388080330363c698fe81f26547426a8f8282/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt#L238) (formerly named "TextField"), a [`CompositionTextField`](https://github.com/orcaformastodon/android/blob/1dbf388080330363c698fe81f26547426a8f8282/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/input/text/TextField.kt#L166).