### PR TITLE
Emit current bottom area offset to a `StateFlow`

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/OrcaActivity.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/OrcaActivity.kt
@@ -25,11 +25,13 @@ import com.jeanbarrossilva.orca.app.databinding.ActivityOrcaBinding
 import com.jeanbarrossilva.orca.app.module.core.MainMastodonCoreModule
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
+import kotlinx.coroutines.flow.MutableStateFlow
 
 internal open class OrcaActivity :
   NavigationActivity(), BottomNavigationViewAvailability, Injection, BottomNavigation {
   protected open val coreModule: CoreModule = MainMastodonCoreModule
 
+  override val yOffsetFlow = MutableStateFlow(0f)
   override var binding: ActivityOrcaBinding? = null
   override var constraintSet: ConstraintSet? = null
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/BottomNavigationViewAvailability.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/BottomNavigationViewAvailability.kt
@@ -21,23 +21,23 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.jeanbarrossilva.orca.app.R
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
+import kotlinx.coroutines.flow.MutableStateFlow
 
 internal interface BottomNavigationViewAvailability :
   OnBottomAreaAvailabilityChangeListener, Binding {
+  override val yOffsetFlow: MutableStateFlow<Float>
+
   var constraintSet: ConstraintSet?
 
   override val height
     get() = binding?.bottomNavigationView?.height ?: 0
 
-  override fun getCurrentOffsetY(): Float {
-    return constraintSet?.getConstraint(R.id.bottom_navigation_view)?.transform?.translationY ?: 0f
-  }
-
-  override fun onBottomAreaAvailabilityChange(offsetY: Float) {
+  override fun onBottomAreaAvailabilityChange(yOffset: Float) {
     constraintSet?.apply {
-      getConstraint(R.id.container).layout.bottomMargin = -offsetY.toInt()
-      getConstraint(R.id.bottom_navigation_view).transform.translationY = offsetY
+      getConstraint(R.id.container).layout.bottomMargin = -yOffset.toInt()
+      getConstraint(R.id.bottom_navigation_view).transform.translationY = yOffset
       applyTo(binding?.root)
+      yOffsetFlow.value = yOffset
     }
   }
 

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/BottomAreaAvailabilityNestedScrollConnection.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/BottomAreaAvailabilityNestedScrollConnection.kt
@@ -28,7 +28,7 @@ class BottomAreaAvailabilityNestedScrollConnection
 internal constructor(private val listener: OnBottomAreaAvailabilityChangeListener) :
   NestedScrollConnection {
   override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-    val currentOffsetY = listener.getCurrentOffsetY()
+    val currentOffsetY = listener.yOffsetFlow.value
     val heightAsFloat = listener.height.toFloat()
     val changedOffsetY = (currentOffsetY - available.y).coerceIn(0f, heightAsFloat)
     listener.onBottomAreaAvailabilityChange(changedOffsetY)

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,33 +15,36 @@
 
 package com.jeanbarrossilva.orca.platform.autos.reactivity
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
 /** Listens to changes on the availability of the utmost bottom portion of the displayed content. */
 interface OnBottomAreaAvailabilityChangeListener {
   /** Provides the height of the UI component in the bottom area. */
   val height: Int
 
-  /** Provides the current offset in the Y-axis of the UI component in the bottom area. */
-  fun getCurrentOffsetY(): Float
+  /**
+   * [StateFlow] to which the current offset in the Y-axis of the UI component in the bottom area is
+   * emitted.
+   */
+  val yOffsetFlow: StateFlow<Float>
 
   /**
    * Callback run whenever the availability of the bottom area is changed.
    *
-   * @param offsetY Amount of offset in the Y-axis to be applied to a UI component in the bottom
+   * @param yOffset Amount of offset in the Y-axis to be applied to a UI component in the bottom
    *   area.
    */
-  fun onBottomAreaAvailabilityChange(offsetY: Float)
+  fun onBottomAreaAvailabilityChange(yOffset: Float)
 
   companion object {
     /** No-op [OnBottomAreaAvailabilityChangeListener]. */
     val empty =
       object : OnBottomAreaAvailabilityChangeListener {
         override val height = 0
+        override val yOffsetFlow = MutableStateFlow(0f)
 
-        override fun getCurrentOffsetY(): Float {
-          return 0f
-        }
-
-        override fun onBottomAreaAvailabilityChange(offsetY: Float) {}
+        override fun onBottomAreaAvailabilityChange(yOffset: Float) {}
       }
   }
 }


### PR DESCRIPTION
Replaces [`OnBottomAreaAvailabilityChangeListener`](https://github.com/orcaformastodon/android/blob/e5479ca63b5cb9fd3a7fadd358251a6f3841a629/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt#L22)'s [`getCurrentOffsetY()`](https://github.com/orcaformastodon/android/blob/45c7540bd489afdc13ee8275dc109bbf7f57e2d0/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt#L24) by [`yOffsetFlow`](https://github.com/orcaformastodon/android/blob/e5479ca63b5cb9fd3a7fadd358251a6f3841a629/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt#L30).