### PR TITLE
Emit bottom area's Y offset to nested scroll connection

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/OrcaActivity.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/OrcaActivity.kt
@@ -25,13 +25,11 @@ import com.jeanbarrossilva.orca.app.databinding.ActivityOrcaBinding
 import com.jeanbarrossilva.orca.app.module.core.MainMastodonCoreModule
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.platform.navigation.NavigationActivity
-import kotlinx.coroutines.flow.MutableStateFlow
 
 internal open class OrcaActivity :
   NavigationActivity(), BottomNavigationViewAvailability, Injection, BottomNavigation {
   protected open val coreModule: CoreModule = MainMastodonCoreModule
 
-  override val yOffsetFlow = MutableStateFlow(0f)
   override var binding: ActivityOrcaBinding? = null
   override var constraintSet: ConstraintSet? = null
 

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/BottomNavigationViewAvailability.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/activity/delegate/BottomNavigationViewAvailability.kt
@@ -21,23 +21,23 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.jeanbarrossilva.orca.app.R
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import kotlinx.coroutines.flow.MutableStateFlow
 
 internal interface BottomNavigationViewAvailability :
   OnBottomAreaAvailabilityChangeListener, Binding {
-  override val yOffsetFlow: MutableStateFlow<Float>
-
   var constraintSet: ConstraintSet?
 
   override val height
     get() = binding?.bottomNavigationView?.height ?: 0
+
+  override fun getCurrentYOffset(): Float {
+    return binding?.bottomNavigationView?.translationY ?: 0f
+  }
 
   override fun onBottomAreaAvailabilityChange(yOffset: Float) {
     constraintSet?.apply {
       getConstraint(R.id.container).layout.bottomMargin = -yOffset.toInt()
       getConstraint(R.id.bottom_navigation_view).transform.translationY = yOffset
       applyTo(binding?.root)
-      yOffsetFlow.value = yOffset
     }
   }
 

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
@@ -43,9 +43,9 @@ import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBarDef
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.plus
 import com.jeanbarrossilva.orca.platform.autos.overlays.asPaddingValues
-import com.jeanbarrossilva.orca.platform.autos.reactivity.BottomAreaAvailabilityNestedScrollConnection
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.autos.reactivity.rememberBottomAreaAvailabilityNestedScrollConnection
+import com.jeanbarrossilva.orca.platform.autos.reactivity.scroll.BottomAreaAvailabilityNestedScrollConnection
+import com.jeanbarrossilva.orca.platform.autos.reactivity.scroll.rememberBottomAreaAvailabilityNestedScrollConnection
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 import java.net.URL

--- a/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetails.kt
+++ b/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetails.kt
@@ -43,9 +43,9 @@ import com.jeanbarrossilva.orca.feature.postdetails.viewmodel.PostDetailsViewMod
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBarDefaults
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBarWithBackNavigation
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
-import com.jeanbarrossilva.orca.platform.autos.reactivity.BottomAreaAvailabilityNestedScrollConnection
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.autos.reactivity.rememberBottomAreaAvailabilityNestedScrollConnection
+import com.jeanbarrossilva.orca.platform.autos.reactivity.scroll.BottomAreaAvailabilityNestedScrollConnection
+import com.jeanbarrossilva.orca.platform.autos.reactivity.scroll.rememberBottomAreaAvailabilityNestedScrollConnection
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.core.withSample

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
@@ -70,9 +70,9 @@ import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBar
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBarDefaults as _TopAppBarDefaults
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.`if`
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
-import com.jeanbarrossilva.orca.platform.autos.reactivity.BottomAreaAvailabilityNestedScrollConnection
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
-import com.jeanbarrossilva.orca.platform.autos.reactivity.rememberBottomAreaAvailabilityNestedScrollConnection
+import com.jeanbarrossilva.orca.platform.autos.reactivity.scroll.BottomAreaAvailabilityNestedScrollConnection
+import com.jeanbarrossilva.orca.platform.autos.reactivity.scroll.rememberBottomAreaAvailabilityNestedScrollConnection
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
 import com.jeanbarrossilva.orca.platform.core.sample

--- a/platform/autos/build.gradle.kts
+++ b/platform/autos/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
   androidTestImplementation(libs.android.test.core)
   androidTestImplementation(libs.android.test.runner)
   androidTestImplementation(libs.assertk)
+  androidTestImplementation(libs.kotlin.test)
 
   api(libs.android.compose.material3)
   api(libs.android.compose.ui.tooling)
@@ -43,5 +44,6 @@ dependencies {
   implementation(libs.loadable.placeholder)
 
   testImplementation(libs.assertk)
+  testImplementation(libs.kotlin.coroutines.test)
   testImplementation(libs.kotlin.test)
 }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/OnBottomAreaAvailabilityChangeListener.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orca
+ * Copyright © 2023 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,19 +15,13 @@
 
 package com.jeanbarrossilva.orca.platform.autos.reactivity
 
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-
 /** Listens to changes on the availability of the utmost bottom portion of the displayed content. */
 interface OnBottomAreaAvailabilityChangeListener {
   /** Provides the height of the UI component in the bottom area. */
   val height: Int
 
-  /**
-   * [StateFlow] to which the current offset in the Y-axis of the UI component in the bottom area is
-   * emitted.
-   */
-  val yOffsetFlow: StateFlow<Float>
+  /** Provides the current offset in the Y-axis of the UI component in the bottom area. */
+  fun getCurrentYOffset(): Float
 
   /**
    * Callback run whenever the availability of the bottom area is changed.
@@ -42,7 +36,10 @@ interface OnBottomAreaAvailabilityChangeListener {
     val empty =
       object : OnBottomAreaAvailabilityChangeListener {
         override val height = 0
-        override val yOffsetFlow = MutableStateFlow(0f)
+
+        override fun getCurrentYOffset(): Float {
+          return 0f
+        }
 
         override fun onBottomAreaAvailabilityChange(yOffset: Float) {}
       }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.extensions.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.extensions.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2023-2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
+
+/**
+ * Remembers a [BottomAreaAvailabilityNestedScrollConnection].
+ *
+ * @param listener [OnBottomAreaAvailabilityChangeListener] to be notified.
+ */
+@Composable
+fun rememberBottomAreaAvailabilityNestedScrollConnection(
+  listener: OnBottomAreaAvailabilityChangeListener
+): BottomAreaAvailabilityNestedScrollConnection {
+  return remember(listener) { BottomAreaAvailabilityNestedScrollConnection(listener) }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,11 +13,17 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.reactivity
+package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.FloatState
+import androidx.compose.runtime.asFloatState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * [NestedScrollConnection] that notifies the [listener] of scroll changes.
@@ -27,11 +33,22 @@ import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 class BottomAreaAvailabilityNestedScrollConnection
 internal constructor(private val listener: OnBottomAreaAvailabilityChangeListener) :
   NestedScrollConnection {
+  /** [MutableStateFlow] to which the current Y offset of the bottom area is emitted. */
+  private var yOffsetFlow = MutableStateFlow(0f)
+
+  /** Current Y offset of the bottom area. */
+  private var yOffset by yOffsetFlow
+
+  /** Gets the current Y offset of the bottom area as a [FloatState]. */
+  @Composable
+  fun getYOffsetAsState(): FloatState {
+    return yOffsetFlow.collectAsState().asFloatState()
+  }
+
   override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-    val currentOffsetY = listener.yOffsetFlow.value
     val heightAsFloat = listener.height.toFloat()
-    val changedOffsetY = (currentOffsetY - available.y).coerceIn(0f, heightAsFloat)
-    listener.onBottomAreaAvailabilityChange(changedOffsetY)
+    yOffset = (yOffset - available.y).coerceIn(0f, heightAsFloat)
+    listener.onBottomAreaAvailabilityChange(yOffset)
     return Offset.Zero
   }
 

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/MutableStateFlow.extensions.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/MutableStateFlow.extensions.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+
+import kotlin.reflect.KProperty
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Changes the value of this [MutableStateFlow] to the given one.
+ *
+ * @param T Value being held.
+ * @param thisRef Object in which access to the value is being performed.
+ * @param property [KProperty] within the [thisRef] by which setting the value is being delegated to
+ *   this method.
+ * @param value Value to which this [MutableStateFlow]'s will be changed.
+ * @see MutableStateFlow.value
+ */
+internal operator fun <T> MutableStateFlow<T>.setValue(
+  thisRef: Any?,
+  property: KProperty<*>,
+  value: T
+) {
+  this.value = value
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/StateFlow.extensions.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/StateFlow.extensions.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+
+import kotlin.reflect.KProperty
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Gets the value of this [StateFlow].
+ *
+ * @param T Value to be obtained.
+ * @param thisRef Object in which access to the value is being performed.
+ * @param property [KProperty] within the [thisRef] by which getting the value is being delegated to
+ *   this method.
+ * @see StateFlow.value
+ */
+internal operator fun <T> StateFlow<T>.getValue(thisRef: Any?, property: KProperty<*>): T {
+  return value
+}

--- a/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/MutableStateFlowExtensionsTests.kt
+++ b/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/MutableStateFlowExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,19 +13,18 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.reactivity
+package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.MutableStateFlow
 
-/**
- * Remembers a [BottomAreaAvailabilityNestedScrollConnection].
- *
- * @param listener [OnBottomAreaAvailabilityChangeListener] to be notified.
- */
-@Composable
-fun rememberBottomAreaAvailabilityNestedScrollConnection(
-  listener: OnBottomAreaAvailabilityChangeListener
-): BottomAreaAvailabilityNestedScrollConnection {
-  return remember(listener) { BottomAreaAvailabilityNestedScrollConnection(listener) }
+internal class MutableStateFlowExtensionsTests {
+  @Test
+  fun setsValue() {
+    var value by MutableStateFlow(0)
+    value = 1
+    assertThat(value).isEqualTo(1)
+  }
 }

--- a/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/StateFlowExtensionsTests.kt
+++ b/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/StateFlowExtensionsTests.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.test.runTest
+
+internal class StateFlowExtensionsTests {
+  @Test
+  fun getsValue() {
+    runTest {
+      val value by flowOf(0).stateIn(this)
+      assertThat(value).isEqualTo(0)
+    }
+  }
+}


### PR DESCRIPTION
Basically moves what's been done in #244 to [`BottomAreaAvailabilityNestedScrollConnection`](https://github.com/orcaformastodon/android/blob/a79b90232abda93c888c8a9ee60ab6dc326bba55/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.kt).