### PR TITLE
Use `StateFlow` value delegates from `:ext:coroutines`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Note that Orca isn't a fork of the official app. Its overall structure has been 
 ## Structure
 
 <div align="center">
-    <img src="https://github.com/orcaformastodon/android/assets/38408390/20215eee-aca6-4bdd-8a29-26c2962d495b" />
+    <img src="https://github.com/orcaformastodon/android/assets/38408390/d5e5fc0a-7f62-442c-a34f-9d4eb7070ef0" />
 </div>
 
 Each module represents the context to which its underlying structures are related.

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -22,7 +22,9 @@ import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.status.MastodonS
 import com.jeanbarrossilva.orca.core.mastodon.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
+import com.jeanbarrossilva.orca.ext.coroutines.getValue
 import com.jeanbarrossilva.orca.ext.coroutines.mapEach
+import com.jeanbarrossilva.orca.ext.coroutines.setValue
 import com.jeanbarrossilva.orca.std.image.ImageLoader
 import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
@@ -70,11 +72,7 @@ internal abstract class MastodonPostPaginator {
    *
    * @see pageFlow
    */
-  private var page
-    get() = pageFlow.value
-    private set(page) {
-      pageFlow.value = page
-    }
+  private var page by pageFlow
 
   /**
    * [ImageLoader.Provider] that provides the [ImageLoader] by which images will be loaded from a

--- a/ext/coroutines/src/main/java/com/jeanbarrossilva/orca/ext/coroutines/MutableStateFlow.extensions.kt
+++ b/ext/coroutines/src/main/java/com/jeanbarrossilva/orca/ext/coroutines/MutableStateFlow.extensions.kt
@@ -13,21 +13,21 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+package com.jeanbarrossilva.orca.ext.coroutines
 
-import assertk.assertThat
-import assertk.assertions.isEqualTo
-import kotlin.test.Test
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.test.runTest
+import kotlin.reflect.KProperty
+import kotlinx.coroutines.flow.MutableStateFlow
 
-internal class StateFlowExtensionsTests {
-  @Test
-  fun getsValue() {
-    runTest {
-      val value by flowOf(0).stateIn(this)
-      assertThat(value).isEqualTo(0)
-    }
-  }
+/**
+ * Changes the value of this [MutableStateFlow] to the given one.
+ *
+ * @param T Value being held.
+ * @param thisRef Object in which access to the value is being performed.
+ * @param property [KProperty] within the [thisRef] by which setting the value is being delegated to
+ *   this method.
+ * @param value Value to which this [MutableStateFlow]'s will be changed.
+ * @see MutableStateFlow.value
+ */
+operator fun <T> MutableStateFlow<T>.setValue(thisRef: Any?, property: KProperty<*>, value: T) {
+  this.value = value
 }

--- a/ext/coroutines/src/main/java/com/jeanbarrossilva/orca/ext/coroutines/StateFlow.extensions.kt
+++ b/ext/coroutines/src/main/java/com/jeanbarrossilva/orca/ext/coroutines/StateFlow.extensions.kt
@@ -13,7 +13,7 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+package com.jeanbarrossilva.orca.ext.coroutines
 
 import kotlin.reflect.KProperty
 import kotlinx.coroutines.flow.StateFlow
@@ -27,6 +27,6 @@ import kotlinx.coroutines.flow.StateFlow
  *   this method.
  * @see StateFlow.value
  */
-internal operator fun <T> StateFlow<T>.getValue(thisRef: Any?, property: KProperty<*>): T {
+operator fun <T> StateFlow<T>.getValue(thisRef: Any?, property: KProperty<*>): T {
   return value
 }

--- a/ext/coroutines/src/test/java/com/jeanbarrossilva/orca/ext/coroutines/MutableStateFlowExtensionsTests.kt
+++ b/ext/coroutines/src/test/java/com/jeanbarrossilva/orca/ext/coroutines/MutableStateFlowExtensionsTests.kt
@@ -13,25 +13,18 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+package com.jeanbarrossilva.orca.ext.coroutines
 
-import kotlin.reflect.KProperty
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
 import kotlinx.coroutines.flow.MutableStateFlow
 
-/**
- * Changes the value of this [MutableStateFlow] to the given one.
- *
- * @param T Value being held.
- * @param thisRef Object in which access to the value is being performed.
- * @param property [KProperty] within the [thisRef] by which setting the value is being delegated to
- *   this method.
- * @param value Value to which this [MutableStateFlow]'s will be changed.
- * @see MutableStateFlow.value
- */
-internal operator fun <T> MutableStateFlow<T>.setValue(
-  thisRef: Any?,
-  property: KProperty<*>,
-  value: T
-) {
-  this.value = value
+internal class MutableStateFlowExtensionsTests {
+  @Test
+  fun setsValue() {
+    var value by MutableStateFlow(0)
+    value = 1
+    assertThat(value).isEqualTo(1)
+  }
 }

--- a/ext/coroutines/src/test/java/com/jeanbarrossilva/orca/ext/coroutines/StateFlowExtensionsTests.kt
+++ b/ext/coroutines/src/test/java/com/jeanbarrossilva/orca/ext/coroutines/StateFlowExtensionsTests.kt
@@ -13,18 +13,21 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.platform.autos.reactivity.scroll
+package com.jeanbarrossilva.orca.ext.coroutines
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlin.test.Test
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.test.runTest
 
-internal class MutableStateFlowExtensionsTests {
+internal class StateFlowExtensionsTests {
   @Test
-  fun setsValue() {
-    var value by MutableStateFlow(0)
-    value = 1
-    assertThat(value).isEqualTo(1)
+  fun getsValue() {
+    runTest {
+      val value by flowOf(0).stateIn(this)
+      assertThat(value).isEqualTo(0)
+    }
   }
 }

--- a/platform/autos/build.gradle.kts
+++ b/platform/autos/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   api(libs.android.compose.ui.tooling)
   api(libs.autos)
 
+  implementation(project(":ext:coroutines"))
   implementation(project(":ext:reflection"))
   implementation(libs.accompanist.adapter)
   implementation(libs.android.material)

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/reactivity/scroll/BottomAreaAvailabilityNestedScrollConnection.kt
@@ -22,6 +22,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import com.jeanbarrossilva.orca.ext.coroutines.getValue
+import com.jeanbarrossilva.orca.ext.coroutines.setValue
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import kotlinx.coroutines.flow.MutableStateFlow
 

--- a/platform/ime/src/androidTest/java/com/jeanbarrossilva/orca/platform/ime/scope/animation/ImeAnimationCallback.kt
+++ b/platform/ime/src/androidTest/java/com/jeanbarrossilva/orca/platform/ime/scope/animation/ImeAnimationCallback.kt
@@ -19,6 +19,8 @@ import android.view.View
 import android.view.WindowInsets
 import android.view.WindowInsetsAnimation
 import com.jeanbarrossilva.orca.ext.coroutines.await
+import com.jeanbarrossilva.orca.ext.coroutines.getValue
+import com.jeanbarrossilva.orca.ext.coroutines.setValue
 import com.jeanbarrossilva.orca.platform.ime.scope.animation.stage.Stage
 import java.time.Duration
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,12 +45,12 @@ internal class ImeAnimationCallback(private val view: View) :
   private val WindowInsetsAnimation.isOfIme
     get() = typeMask and type == type
 
-  /** Current [Stage] of the ongoing [WindowInsetsAnimation]. */
-  var stage
-    get() = stageFlow.value
-    private set(stage) {
-      stageFlow.value = stage
-    }
+  /**
+   * Current [Stage] of the ongoing [WindowInsetsAnimation].
+   *
+   * @see stageFlow
+   */
+  var stage by stageFlow
 
   init {
     stage = Stage.idle()


### PR DESCRIPTION
Moves the [`StateFlow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow) and [`MutableStateFlow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow) value delegates from [`:platform:autos`](https://github.com/orcaformastodon/android/tree/091616abf03392b1d87f7dd678aeaca7312a0a45/platform/autos) to [`:ext:coroutines`](https://github.com/orcaformastodon/android/tree/091616abf03392b1d87f7dd678aeaca7312a0a45/ext/coroutines), utilizing them in places at which variables had their getters and setters solely reading and setting the value of a [`MutableStateFlow`](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-mutable-state-flow).