### PR TITLE
Fix unscaled and uncropped small gallery images

### DIFF
--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/NavigatorFeedBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/feed/NavigatorFeedBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.app.module.feature.feed
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.ext.intents.browseTo
 import com.jeanbarrossilva.orca.feature.composer.ComposerActivity
@@ -44,7 +45,7 @@ internal class NavigatorFeedBoundary(
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   ) {
     GalleryActivity.start(context, postID, entrypointIndex, secondary, entrypoint)
   }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/NavigatorPostDetailsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/postdetails/NavigatorPostDetailsBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.app.module.feature.postdetails
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.ext.intents.browseTo
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
@@ -38,7 +39,7 @@ internal class NavigatorPostDetailsBoundary(
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   ) {
     GalleryActivity.start(context, postID, entrypointIndex, secondary, entrypoint)
   }

--- a/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/NavigatorProfileDetailsBoundary.kt
+++ b/app/src/main/java/com/jeanbarrossilva/orca/app/module/feature/profiledetails/NavigatorProfileDetailsBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.app.module.feature.profiledetails
 import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.ext.intents.browseTo
 import com.jeanbarrossilva.orca.feature.gallery.GalleryActivity
@@ -38,7 +39,7 @@ internal class NavigatorProfileDetailsBoundary(
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   ) {
     GalleryActivity.start(context, postID, entrypointIndex, secondary, entrypoint)
   }

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/disposition/Disposition.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/disposition/Disposition.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -71,7 +72,7 @@ sealed class Disposition {
       postID: String,
       entrypointIndex: Int,
       secondary: List<Attachment>,
-      entrypoint: @Composable (Modifier) -> Unit
+      entrypoint: @Composable (ContentScale, Modifier) -> Unit
     )
 
     companion object {

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/thumbnail/Thumbnail.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/post/figure/gallery/thumbnail/Thumbnail.kt
@@ -35,6 +35,7 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.platform.autos.forms.asShape
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
+import com.jeanbarrossilva.orca.std.image.compose.ComposableImageLoader
 import com.jeanbarrossilva.orca.std.image.compose.rememberImageLoader
 
 /** Tag that identifies a [Thumbnail] for testing purposes. */
@@ -72,23 +73,25 @@ internal fun Thumbnail(
   authorName: String,
   attachment: Attachment,
   @IntRange(from = 1) position: Int,
-  onClick: (copy: @Composable (Modifier) -> Unit) -> Unit,
+  onClick: (copy: @Composable (ContentScale, Modifier) -> Unit) -> Unit,
   modifier: Modifier = Modifier,
   shape: Shape = ThumbnailDefaults.shape
 ) {
-  val thumbnail: @Composable (Modifier) -> Unit = {
-    rememberImageLoader(attachment.url).load()(
-      stringResource(
-        R.string.composite_timeline_post_preview_gallery_thumbnail,
-        position,
-        authorName
-      ),
-      RectangleShape,
-      ContentScale.FillWidth,
-      it
-    )
-  }
+  val thumbnail =
+    @Composable { contentScale: ContentScale, thumbnailModifier: Modifier ->
+      rememberImageLoader(attachment.url).load()(
+        stringResource(
+          R.string.composite_timeline_post_preview_gallery_thumbnail,
+          position,
+          authorName
+        ),
+        RectangleShape,
+        contentScale,
+        thumbnailModifier
+      )
+    }
   thumbnail(
+    ComposableImageLoader.DefaultContentScale,
     modifier
       .clip(shape)
       .clickable { onClick(thumbnail) }

--- a/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedBoundary.kt
+++ b/feature/feed/src/androidTest/java/com/jeanbarrossilva/orca/feature/feed/test/TestFeedBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.feature.feed.test
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.feature.feed.FeedBoundary
 import java.net.URL
@@ -30,7 +31,7 @@ internal class TestFeedBoundary : FeedBoundary {
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   ) {}
 
   override fun navigateToPostDetails(id: String) {}

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedBoundary.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.feature.feed
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import java.net.URL
 
@@ -29,7 +30,7 @@ interface FeedBoundary {
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   )
 
   fun navigateToPostDetails(id: String)

--- a/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ActivityScenario.extensions.kt
+++ b/feature/gallery/src/androidTest/java/com/jeanbarrossilva/orca/feature/gallery/test/ActivityScenario.extensions.kt
@@ -47,15 +47,15 @@ internal fun launchGalleryActivity(
   postID: String = Posts.withSample.single().id,
   entrypointIndex: Int = 0,
   secondary: List<Attachment> = Attachment.samples,
-  entrypoint: @Composable (Modifier) -> Unit = {
+  entrypoint: @Composable (ContentScale, Modifier) -> Unit = { contentScale, modifier ->
     ComposableImageLoader.createSample(CoverImageSource.Default).load()(
       stringResource(
         com.jeanbarrossilva.orca.feature.gallery.R.string.feature_gallery_attachment,
         1.formatted
       ),
       RectangleShape,
-      ContentScale.FillWidth,
-      it
+      contentScale,
+      modifier
     )
   }
 ): ActivityScenario<GalleryActivity> {

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivity.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryActivity.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.composite.composable.ComposableActivity
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.ext.intents.intentOf
@@ -40,7 +41,7 @@ class GalleryActivity internal constructor() : ComposableActivity() {
   private val secondary by extra<List<Attachment>>(SECONDARY_KEY)
 
   @set:JvmName("_setEntrypoint")
-  private var entrypoint by mutableStateOf<(@Composable (Modifier) -> Unit)?>(null)
+  private var entrypoint by mutableStateOf<(@Composable (ContentScale, Modifier) -> Unit)?>(null)
 
   private val viewModel by
     viewModels<GalleryViewModel> {
@@ -55,11 +56,11 @@ class GalleryActivity internal constructor() : ComposableActivity() {
   @Composable
   override fun Content() {
     Gallery(viewModel, module.boundary(), entrypointIndex, secondary, onClose = ::finish) {
-      entrypoint?.invoke(it)
+      entrypoint?.invoke(ContentScale.FillWidth, it)
     }
   }
 
-  fun setEntrypoint(entrypoint: @Composable (Modifier) -> Unit) {
+  fun setEntrypoint(entrypoint: @Composable (ContentScale, Modifier) -> Unit) {
     this.entrypoint = entrypoint
   }
 
@@ -87,7 +88,7 @@ class GalleryActivity internal constructor() : ComposableActivity() {
       postID: String,
       entrypointIndex: Int,
       secondary: List<Attachment>,
-      entrypoint: @Composable (Modifier) -> Unit
+      entrypoint: @Composable (ContentScale, Modifier) -> Unit
     ) {
       context
         .on<GalleryActivity>()

--- a/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsBoundary.kt
+++ b/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.feature.postdetails
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import java.net.URL
 
@@ -27,7 +28,7 @@ interface PostDetailsBoundary {
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   )
 
   fun navigateToPostDetails(id: String)

--- a/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsBoundary.kt
+++ b/feature/profile-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/profiledetails/test/TestProfileDetailsBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.feature.profiledetails.test
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import com.jeanbarrossilva.orca.feature.profiledetails.ProfileDetailsBoundary
 import java.net.URL
@@ -28,7 +29,7 @@ internal class TestProfileDetailsBoundary : ProfileDetailsBoundary {
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   ) {}
 
   override fun navigateToPostDetails(id: String) {}

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsBoundary.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsBoundary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.feature.profiledetails
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Attachment
 import java.net.URL
 
@@ -27,7 +28,7 @@ interface ProfileDetailsBoundary {
     postID: String,
     entrypointIndex: Int,
     secondary: List<Attachment>,
-    entrypoint: @Composable (Modifier) -> Unit
+    entrypoint: @Composable (ContentScale, Modifier) -> Unit
   )
 
   fun navigateToPostDetails(id: String)
@@ -41,7 +42,7 @@ interface ProfileDetailsBoundary {
           postID: String,
           entrypointIndex: Int,
           secondary: List<Attachment>,
-          entrypoint: @Composable (Modifier) -> Unit
+          entrypoint: @Composable (ContentScale, Modifier) -> Unit
         ) {}
 
         override fun navigateToPostDetails(id: String) {}

--- a/std/image/compose/src/main/java/com/jeanbarrossilva/orca/std/image/compose/async/AsyncImageLoader.kt
+++ b/std/image/compose/src/main/java/com/jeanbarrossilva/orca/std/image/compose/async/AsyncImageLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -18,6 +18,7 @@ package com.jeanbarrossilva.orca.std.image.compose.async
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
@@ -74,7 +75,7 @@ class AsyncImageLoader private constructor(override val source: URL) :
           AsyncImage(
             "$source",
             contentDescription,
-            Modifier.clip(shape).clearAndSetSemantics {},
+            Modifier.clip(shape).fillMaxSize().clearAndSetSemantics {},
             onState = { state = it },
             contentScale = contentScale
           )


### PR DESCRIPTION
Thumbnails were being shown in their real size. That means that, if they were small, they wouldn't fill the width of the whole container.

<img src="https://github.com/orcaformastodon/android/assets/38408390/a82a67d6-0c37-42c1-a067-bbe6c31c1daa" width="256" />
<img src="https://github.com/orcaformastodon/android/assets/38408390/bd1f61b9-8598-46b1-a259-7037ee480a7d" width="256" />
