### PR TITLE
Fix unloading timeline

### DIFF
--- a/composite/timeline/build.gradle.kts
+++ b/composite/timeline/build.gradle.kts
@@ -29,7 +29,6 @@ android {
 dependencies {
   androidTestImplementation(project(":composite:timeline-test"))
   androidTestImplementation(project(":core:sample-test"))
-  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(libs.android.compose.ui.test.junit)
   androidTestImplementation(libs.android.compose.ui.test.manifest)
   androidTestImplementation(libs.android.test.core)

--- a/composite/timeline/build.gradle.kts
+++ b/composite/timeline/build.gradle.kts
@@ -29,6 +29,7 @@ android {
 dependencies {
   androidTestImplementation(project(":composite:timeline-test"))
   androidTestImplementation(project(":core:sample-test"))
+  androidTestImplementation(project(":platform:testing"))
   androidTestImplementation(libs.android.compose.ui.test.junit)
   androidTestImplementation(libs.android.compose.ui.test.manifest)
   androidTestImplementation(libs.android.test.core)

--- a/composite/timeline/src/androidTest/java/com/jeanbarrossilva/orca/composite/timeline/TimelineTests.kt
+++ b/composite/timeline/src/androidTest/java/com/jeanbarrossilva/orca/composite/timeline/TimelineTests.kt
@@ -16,7 +16,6 @@
 package com.jeanbarrossilva.orca.composite.timeline
 
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
@@ -45,7 +44,6 @@ import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.sample.test.instance.SampleInstanceTestRule
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import com.jeanbarrossilva.orca.platform.core.sample
-import com.jeanbarrossilva.orca.platform.testing.screen.screen
 import kotlin.time.Duration.Companion.days
 import org.junit.Rule
 import org.junit.Test
@@ -126,9 +124,7 @@ internal class TimelineTests {
     composeRule
       .apply {
         setContent {
-          Timeline(onNext = { indices += it }) {
-            item { Spacer(Modifier.height(screen.height.inDps).fillParentMaxWidth()) }
-          }
+          Timeline(onNext = { indices += it }) { item { Spacer(Modifier.fillParentMaxSize()) } }
         }
       }
       .onTimeline()

--- a/composite/timeline/src/androidTest/java/com/jeanbarrossilva/orca/composite/timeline/TimelineTests.kt
+++ b/composite/timeline/src/androidTest/java/com/jeanbarrossilva/orca/composite/timeline/TimelineTests.kt
@@ -107,7 +107,7 @@ internal class TimelineTests {
       Timeline(
         onNext = {
           if (indices.size < 2) {
-            indices += indices.lastOrNull()?.inc() ?: 0
+            indices += it
           }
         }
       ) {
@@ -117,7 +117,7 @@ internal class TimelineTests {
     composeRule.onTimeline().performScrollToBottom()
     composeRule.waitUntil { indices.size == 2 }
     composeRule.onTimeline().performScrollToBottom()
-    assertThat(indices).containsExactly(0, 1)
+    assertThat(indices).containsExactly(1, 2)
   }
 
   @Test
@@ -135,6 +135,6 @@ internal class TimelineTests {
       .performScrollToBottom()
       .performTouchInput(TouchInjectionScope::swipeDown)
       .performScrollToBottom()
-    assertThat(indices).isEqualTo(hashSetOf(0))
+    assertThat(indices).isEqualTo(hashSetOf(1))
   }
 }

--- a/composite/timeline/src/androidTest/java/com/jeanbarrossilva/orca/composite/timeline/TimelineTests.kt
+++ b/composite/timeline/src/androidTest/java/com/jeanbarrossilva/orca/composite/timeline/TimelineTests.kt
@@ -112,9 +112,7 @@ internal class TimelineTests {
         items(indices) { Spacer(Modifier.fillParentMaxSize()) }
       }
     }
-    composeRule.onTimeline().performScrollToBottom()
-    composeRule.waitUntil { indices.size == 2 }
-    composeRule.onTimeline().performScrollToBottom()
+    composeRule.onTimeline().performScrollToBottom().performScrollToBottom()
     assertThat(indices).containsExactly(1, 2)
   }
 

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/RenderEffect.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/RenderEffect.kt
@@ -56,7 +56,7 @@ private object RenderEffectKey : Serializable {
  *
  * @param contentType Content type to be associated to the [RenderEffect] for Compose to be able to
  *   reuse it.
- * @param keys Values to which changes indicates whether the effect should be reset and its next
+ * @param keys Values to which changes indicate whether the effect should be reset and its next
  *   rendering should be taken into account. Note that these aren't identifiers for the
  *   [RenderEffect] item to be added.
  * @param effect Callback run when the [RenderEffect] is rendered.
@@ -71,7 +71,7 @@ internal fun LazyListScope.renderEffect(contentType: Any, vararg keys: Any?, eff
  *
  * @param keys Values to which changes indicate that the [effect] should be run.
  * @param effect Operation to be performed once this [Composable] is rendered for the first time and
- *   when the [keys] changes.
+ *   when the [keys] change.
  */
 @Composable
 private fun RenderEffect(vararg keys: Any?, effect: () -> Unit) {

--- a/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/Timeline.kt
+++ b/composite/timeline/src/main/java/com/jeanbarrossilva/orca/composite/timeline/Timeline.kt
@@ -105,7 +105,9 @@ private enum class TimelineContentType {
  * @param onShare Callback run whenever a [PostPreview] requests the [Post]'s [URL] is requested to
  *   be shared.
  * @param onClick Callback run whenever the [PostPreview] associated to the given ID is clicked.
- * @param onNext Callback run whenever the bottom is being reached.
+ * @param onNext Operation to be performed whenever pagination is requested. Provided index starts
+ *   at one, mainly because it is implied that the current page is 0 if the content has already been
+ *   loaded.
  * @param modifier [Modifier] to be applied to the underlying [LazyColumn].
  * @param state [LazyListState] through which scroll will be observed.
  * @param contentPadding [PaddingValues] to pad the content with.
@@ -181,7 +183,9 @@ fun Timeline(
  * @param onShare Callback run whenever a [PostPreview] requests the [Post]'s [URL] is requested to
  *   be shared.
  * @param onClick Callback run whenever the [PostPreview] associated to the given ID is clicked.
- * @param onNext Callback run whenever the bottom is being reached.
+ * @param onNext Operation to be performed whenever pagination is requested. Provided index starts
+ *   at one, mainly because it is implied that the current page is 0 if the content has already been
+ *   loaded.
  * @param modifier [Modifier] to be applied to the underlying [LazyColumn].
  * @param state [LazyListState] through which scroll will be observed.
  * @param contentPadding [PaddingValues] to pad the content with.
@@ -234,7 +238,9 @@ fun Timeline(
 /**
  * [LazyColumn] for displaying paged content.
  *
- * @param onNext Callback run whenever the bottom is being reached.
+ * @param onNext Operation to be performed whenever pagination is requested. Provided index starts
+ *   at one, mainly because it is implied that the current page is 0 if the content has already been
+ *   loaded.
  * @param modifier [Modifier] to be applied to the underlying [LazyColumn].
  * @param header [Composable] to be shown above the [content].
  * @param state [LazyListState] through which scroll will be observed.
@@ -258,7 +264,7 @@ fun Timeline(
     derivedStateOf(structuralEqualityPolicy()) { state.layoutInfo.totalItemsCount }
   }
   var itemCountPriorToLastPagination by remember { mutableStateOf<Int?>(null) }
-  var index by remember { mutableIntStateOf(0) }
+  var index by remember { mutableIntStateOf(1) }
   val paginate by rememberUpdatedState {
     itemCountPriorToLastPagination = itemCount
     onNext(index++)

--- a/core/mastodon/build.gradle.kts
+++ b/core/mastodon/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
   implementation(project(":platform:starter"))
   implementation(libs.android.browser)
   implementation(libs.android.room.ktx)
+  implementation(libs.kotlin.reflect)
   implementation(libs.ktor.client.cio)
   implementation(libs.ktor.client.core)
   implementation(libs.ktor.client.contentNegotiation)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/MastodonFeedPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/MastodonFeedPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,12 +17,15 @@ package com.jeanbarrossilva.orca.core.mastodon.feed
 
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.MastodonPost
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.MastodonPostPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.MastodonStatusesPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
 import java.net.URL
 
 /** [MastodonPostPaginator] that paginates through [MastodonPost]s of the feed. */
 internal class MastodonFeedPaginator(
-  override val imageLoaderProvider: SomeImageLoaderProvider<URL>
-) : MastodonPostPaginator() {
+  override val imageLoaderProvider: SomeImageLoaderProvider<URL>,
+  override val commentPaginatorProvider: MastodonCommentPaginator.Provider
+) : MastodonStatusesPaginator() {
   override val route = "/api/v1/timelines/home"
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/MastodonProfilePostPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/MastodonProfilePostPaginator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,29 +15,35 @@
 
 package com.jeanbarrossilva.orca.core.mastodon.feed.profile
 
-import com.jeanbarrossilva.orca.core.feed.profile.post.Post
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.account.MastodonAccount
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.MastodonPostPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.MastodonStatusesPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.status.MastodonStatus
 import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
 import java.net.URL
 
 /**
- * [MastodonPostPaginator] that paginates through a [MastodonProfile]'s [Post]s.
+ * [MastodonPostPaginator] that paginates through a [MastodonAccount]'s [MastodonStatus]es.
  *
- * @param id ID of the [MastodonProfile].
+ * @param id ID of the [MastodonAccount].
+ * @see MastodonAccount.id
  */
 internal class MastodonProfilePostPaginator(
   override val imageLoaderProvider: SomeImageLoaderProvider<URL>,
+  override val commentPaginatorProvider: MastodonCommentPaginator.Provider,
   id: String
-) : MastodonPostPaginator() {
+) : MastodonStatusesPaginator() {
   override val route = "/api/v1/accounts/$id/statuses"
 
   /** Provides a [MastodonProfilePostPaginator] through [provide]. */
   fun interface Provider {
     /**
-     * Provides a [MastodonProfilePostPaginator] that paginates through the [Post]s of a
-     * [MastodonProfile] identified as [id].
+     * Provides a [MastodonProfilePostPaginator] that paginates through the [MastodonStatus]es of a
+     * [MastodonAccount] identified as [id].
      *
-     * @param id ID of the [MastodonProfile].
+     * @param id ID of the [MastodonAccount].
+     * @see MastodonAccount.id
      */
     fun provide(id: String): MastodonProfilePostPaginator
   }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/MastodonPost.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/MastodonPost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -19,9 +19,10 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.Author
 import com.jeanbarrossilva.orca.core.feed.profile.post.DeletablePost
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Content
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.CommentStat
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.FavoriteStat
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.ReblogStat
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.CommentStat
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import com.jeanbarrossilva.orca.std.image.ImageLoader
 import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
 import java.net.URL
@@ -32,23 +33,27 @@ import java.time.ZonedDateTime
  *
  * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
  *   will be loaded from a [URL].
+ * @param commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
+ *   [MastodonCommentPaginator] for paginating through the comments will be provided.
  * @param commentCount Amount of comments that this [MastodonPost] has received.
  * @param favoriteCount Amount of times that this [MastodonPost] has been marked as favorite.
  * @param reblogCount Amount of times that this [MastodonPost] has been reblogged.
+ * @see comment
  */
 data class MastodonPost
 internal constructor(
   override val id: String,
+  private val imageLoaderProvider: SomeImageLoaderProvider<URL>,
   override val author: Author,
   override val content: Content,
-  private val imageLoaderProvider: SomeImageLoaderProvider<URL>,
   override val publicationDateTime: ZonedDateTime,
+  private val commentPaginatorProvider: MastodonCommentPaginator.Provider,
   private val commentCount: Int,
   private val favoriteCount: Int,
   private val reblogCount: Int,
   override val url: URL
 ) : Post() {
-  override val comment = CommentStat(id, commentCount, imageLoaderProvider)
+  override val comment = CommentStat(id, commentCount, commentPaginatorProvider)
   override val favorite = FavoriteStat(id, favoriteCount)
   override val repost = ReblogStat(id, reblogCount)
 

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/cache/MastodonPostFetcher.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/cache/MastodonPostFetcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -17,6 +17,7 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.cache
 
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import com.jeanbarrossilva.orca.core.mastodon.client.authenticateAndGet
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.status.MastodonStatus
 import com.jeanbarrossilva.orca.core.mastodon.instance.SomeHttpInstance
 import com.jeanbarrossilva.orca.core.module.CoreModule
@@ -33,14 +34,19 @@ import java.net.URL
  *
  * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
  *   will be loaded from a [URL].
+ * @param commentPaginatorProvider [MastodonCommentPaginator] by which a [MastodonCommentPaginator]
+ *   for paginating through the fetched [Post]s will be provided.
+ * @see Post.comment
  */
-internal class MastodonPostFetcher(private val imageLoaderProvider: SomeImageLoaderProvider<URL>) :
-  Fetcher<Post>() {
+internal class MastodonPostFetcher(
+  private val imageLoaderProvider: SomeImageLoaderProvider<URL>,
+  private val commentPaginatorProvider: MastodonCommentPaginator.Provider
+) : Fetcher<Post>() {
   override suspend fun onFetch(key: String): Post {
     return (Injector.from<CoreModule>().instanceProvider().provide() as SomeHttpInstance)
       .client
       .authenticateAndGet("/api/v1/statuses/$key")
       .body<MastodonStatus>()
-      .toPost(imageLoaderProvider)
+      .toPost(imageLoaderProvider, commentPaginatorProvider)
   }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/cache/storage/MastodonPostEntity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -28,6 +28,7 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.content.highlight.Highlig
 import com.jeanbarrossilva.orca.core.feed.profile.post.repost.Repost
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.cache.storage.style.MastodonStyleEntity
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.MastodonPost
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.`if`
@@ -85,11 +86,15 @@ internal data class MastodonPostEntity(
    *   [Mastodon style entities][MastodonStyleEntity].
    * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by images
    *   will be loaded from a [URL].
+   * @param commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
+   *   [MastodonCommentPaginator] for paginating through the [Post]'s comments will be provided.
+   * @see Post.comment
    */
   suspend fun toPost(
     profileCache: Cache<Profile>,
     dao: MastodonPostEntityDao,
-    imageLoaderProvider: SomeImageLoaderProvider<URL>
+    imageLoaderProvider: SomeImageLoaderProvider<URL>,
+    commentPaginatorProvider: MastodonCommentPaginator.Provider
   ): Post {
     val author = profileCache.get(authorID).toAuthor()
     val domain = Injector.from<CoreModule>().instanceProvider().provide().domain
@@ -108,10 +113,11 @@ internal data class MastodonPostEntity(
     val url = URL(url)
     return MastodonPost(
         id,
+        imageLoaderProvider,
         author,
         content,
-        imageLoaderProvider,
         publicationDateTime,
+        commentPaginatorProvider,
         commentCount,
         favoriteCount,
         repostCount,

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponse.extensions.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponse.extensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
+
+import io.ktor.client.call.DoubleReceiveException
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.statement.HttpResponse
+import io.ktor.util.reflect.TypeInfo
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.javaType
+
+/**
+ * Receives the payload as being a [T].
+ *
+ * @param T Body to be obtained.
+ * @param typeCreator [KTypeCreator] by which a [KType] for the [bodyClass] will be created.
+ * @param bodyClass [KClass] of the body to be returned.
+ * @throws DoubleReceiveException If the payload has already been received.
+ * @throws NoTransformationFoundException If no transformation for [T] is found.
+ */
+@Throws(DoubleReceiveException::class, NoTransformationFoundException::class)
+internal suspend fun <T : Any> HttpResponse.body(
+  typeCreator: KTypeCreator,
+  bodyClass: KClass<T>
+): T {
+  val type = typeCreator.create(bodyClass)
+  @OptIn(ExperimentalStdlibApi::class) val typeInfo = TypeInfo(bodyClass, type.javaType, type)
+  return body(typeInfo)
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreator.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
+
+import io.ktor.client.statement.HttpResponse
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
+
+/**
+ * Creates a [KType] from a [KClass].
+ *
+ * Such behavior is necessary because of the generic nature of a [MastodonPostPaginator]: since its
+ * type parameter (which is the DTO to be received from the API when pagination takes place) cannot
+ * be reified (at least not as of Kotlin 1.9.21), the [HttpResponse] needs to know how to actually
+ * convert the payload into the specified object. Tends to result in a somewhat manual process if
+ * there are, for example, type arguments that need to be given; otherwise, a default [KTypeCreator]
+ * can automatically do the work all by itself.
+ *
+ * It is primarily taken advantage of by Orca's own implementation of [HttpResponse.body], which
+ * takes a [KClass] in instead of a reified type parameter (as does [io.ktor.client.call.body]).
+ *
+ * @see defaultFor
+ */
+internal interface KTypeCreator {
+  /**
+   * Creates a [KType] from the [kClass].
+   *
+   * @param kClass [KClass] for which the [KType] to be created is.
+   */
+  fun create(kClass: KClass<*>): KType
+
+  companion object {
+    /**
+     * [IllegalArgumentException] thrown if a [KType] is tried to be created for a [KClass] that
+     * cannot be handled by a default [KTypeCreator].
+     *
+     * @param kClass [KClass] for which a [KType] couldn't be created.
+     * @see defaultFor
+     */
+    class ComplexTypeException(kClass: KClass<*>) :
+      IllegalArgumentException("Cannot create a type from a $kClass with a default creator.")
+
+    /**
+     * [KTypeCreator] that creates a [KType] from a [KClass] through [createType], without
+     * specifying any type parameters or annotations. Useful for simpler types that do not require
+     * these details to be set.
+     *
+     * **NOTE**: A [ComplexTypeException] will be thrown if [T] is a complex type and a [KType] for
+     * a [KClass] of it is requested to be created, denoting that it should be done so manually
+     * instead of delegating the creation to a default [KTypeCreator].
+     */
+    fun <T : Any> defaultFor(): KTypeCreator {
+      return object : KTypeCreator {
+        override fun create(kClass: KClass<*>): KType {
+          return try {
+            kClass.createType()
+          } catch (_: IllegalArgumentException) {
+            throw ComplexTypeException(kClass)
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
+
+import com.jeanbarrossilva.orca.core.feed.profile.post.Post
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.status.MastodonStatus
+import com.jeanbarrossilva.orca.std.image.ImageLoader
+import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
+import java.net.URL
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.full.createType
+import kotlin.reflect.typeOf
+
+/** [MastodonPostPaginator] that receives a [List] of [MastodonStatus]es from the API. */
+internal abstract class MastodonStatusesPaginator : MastodonPostPaginator<List<MastodonStatus>>() {
+  /**
+   * [ImageLoader.Provider] that provides the [ImageLoader] by which images will be loaded from a
+   * [URL].
+   */
+  protected abstract val imageLoaderProvider: SomeImageLoaderProvider<URL>
+
+  /**
+   * [MastodonCommentPaginator.Provider] through which a [MastodonCommentPaginator] for paginating
+   * through the comments of the retrieved [Post]s will be provided.
+   *
+   * @see Post.comment
+   */
+  protected abstract val commentPaginatorProvider: MastodonCommentPaginator.Provider
+
+  @Suppress("UNCHECKED_CAST")
+  final override val dtoClass = List::class as KClass<List<MastodonStatus>>
+
+  final override fun create(kClass: KClass<*>): KType {
+    val statusType = typeOf<MastodonStatus>()
+    val statusProjection = KTypeProjection(KVariance.OUT, statusType)
+    val arguments = listOf(statusProjection)
+    return kClass.createType(arguments)
+  }
+
+  final override fun List<MastodonStatus>.toMastodonPosts(): List<Post> {
+    return map { it.toPost(imageLoaderProvider, commentPaginatorProvider) }
+  }
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment
+
+import com.jeanbarrossilva.orca.core.feed.profile.post.Post
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.MastodonProfilePostPaginator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.MastodonContext
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.KTypeCreator
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.MastodonPostPaginator
+import com.jeanbarrossilva.orca.std.image.ImageLoader
+import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
+import java.net.URL
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+/**
+ * [MastodonPostPaginator] for paginating through the comments of a [Post].
+ *
+ * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which images
+ *   will be loaded from a [URL].
+ * @param id ID of the original [Post].
+ * @see Post.comment
+ * @see Post.id
+ */
+internal class MastodonCommentPaginator(
+  private val imageLoaderProvider: SomeImageLoaderProvider<URL>,
+  id: String
+) : MastodonPostPaginator<MastodonContext>() {
+  override val route = "/api/v1/statuses/$id/context"
+  override val dtoClass = MastodonContext::class
+
+  /** Provides a [MastodonProfilePostPaginator] through [provide]. */
+  fun interface Provider {
+    /**
+     * Provides a [MastodonCommentPaginator] that paginates through the comments of a [Post]
+     * identified as [id].
+     *
+     * @param id ID of the original [Post].
+     * @see Post.comment
+     * @see Post.id
+     */
+    fun provide(id: String): MastodonCommentPaginator
+  }
+
+  override fun create(kClass: KClass<*>): KType {
+    return KTypeCreator.defaultFor<MastodonContext>().create(kClass)
+  }
+
+  override fun MastodonContext.toMastodonPosts(): List<Post> {
+    return descendants.map { it.toPost(imageLoaderProvider) { this@MastodonCommentPaginator } }
+  }
+}

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -22,6 +22,7 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.content.Content
 import com.jeanbarrossilva.orca.core.feed.profile.post.repost.Repost
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.account.MastodonAccount
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.MastodonPost
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import com.jeanbarrossilva.orca.core.module.CoreModule
 import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.`if`
@@ -75,8 +76,14 @@ internal constructor(
    *
    * @param imageLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which
    *   images will be loaded from a [URL].
+   * @param commentPaginatorProvider [MastodonCommentPaginator.Provider] by which a
+   *   [MastodonCommentPaginator] for paginating through the comments will be provided.
+   * @see Post.comment
    */
-  internal fun toPost(imageLoaderProvider: SomeImageLoaderProvider<URL>): Post {
+  internal fun toPost(
+    imageLoaderProvider: SomeImageLoaderProvider<URL>,
+    commentPaginatorProvider: MastodonCommentPaginator.Provider
+  ): Post {
     val author =
       reblog?.account?.toAuthor(imageLoaderProvider) ?: account.toAuthor(imageLoaderProvider)
     val domain = Injector.from<CoreModule>().instanceProvider().provide().domain
@@ -88,10 +95,11 @@ internal constructor(
     val url = URL(reblog?.url ?: url)
     return MastodonPost(
         id,
+        imageLoaderProvider,
         author,
         content,
-        imageLoaderProvider,
         publicationDateTime,
+        commentPaginatorProvider,
         commentCount = reblog?.repliesCount ?: repliesCount,
         favouritesCount,
         reblogsCount,

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/client/test/instance/TestMastodonInstance.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/client/test/instance/TestMastodonInstance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponseExtensionsTests.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponseExtensionsTests.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.jeanbarrossilva.orca.core.mastodon.client.CoreHttpClient
+import com.jeanbarrossilva.orca.core.mastodon.client.Logger
+import com.jeanbarrossilva.orca.core.mastodon.client.test.instance.test
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.request.get
+import kotlin.test.Test
+import kotlinx.coroutines.test.runTest
+
+internal class HttpResponseExtensionsTests {
+  @Test
+  fun getsBody() {
+    runTest {
+      assertThat(
+          CoreHttpClient(
+              object : HttpClientEngineFactory<MockEngineConfig> {
+                override fun create(block: MockEngineConfig.() -> Unit): MockEngine {
+                  return MockEngine { respondOk("Hello, world!") }.apply { block(config) }
+                }
+              },
+              Logger.test
+            )
+            .get("/")
+            .body(KTypeCreator.defaultFor<String>(), String::class)
+        )
+        .isEqualTo("Hello, world!")
+    }
+  }
+}

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreatorTests.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreatorTests.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+
+internal class KTypeCreatorTests {
+  @Test(KTypeCreator.Companion.ComplexTypeException::class)
+  fun throwsWhenCreatingComplexTypeWithDefaultCreator() {
+    KTypeCreator.defaultFor<List<Any>>().create(List::class)
+  }
+
+  @Test
+  fun defaultCreatorCreatesSimpleType() {
+    assertThat(KTypeCreator.defaultFor<String>().create(String::class)).isEqualTo(typeOf<String>())
+  }
+}

--- a/ext/coroutines/src/main/java/com/jeanbarrossilva/orca/ext/coroutines/pagination/Flow.extensions.kt
+++ b/ext/coroutines/src/main/java/com/jeanbarrossilva/orca/ext/coroutines/pagination/Flow.extensions.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.ext.coroutines.pagination
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.runningReduce
+
+/**
+ * Combines index-based [Flow]s of [Iterable]s into one.
+ *
+ * @param T Contained element to be appended when pagination is performed.
+ * @param pagination Returns a [Flow] that emits values related to the given index, which will be
+ *   appended to the ones that have been given for previous indices, and, finally, emitted to the
+ *   resulting [Flow].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+fun <T> Flow<Int>.paginate(pagination: suspend (index: Int) -> Flow<Iterable<T>>): Flow<List<T>> {
+  @Suppress("UNCHECKED_CAST")
+  return distinctUntilChanged().flatMapMerge(transform = pagination).runningReduce {
+    accumulator,
+    posts ->
+    accumulator + posts
+  } as Flow<List<T>>
+}


### PR DESCRIPTION
Timeline's pagination callback wasn't getting called, which made only the first page of the feed, a post's comments and a profile's posts load.