### PR TITLE
Fix indefinite article typos in documentation

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/account/MastodonAccount.kt
@@ -119,7 +119,7 @@ internal data class MastodonAccount(
   }
 
   /**
-   * Converts this [MastodonAccount] into an [MastodonEditableProfile].
+   * Converts this [MastodonAccount] into A [MastodonEditableProfile].
    *
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   [MastodonEditableProfile]'s avatar will be loaded from a [URL].
@@ -150,7 +150,7 @@ internal data class MastodonAccount(
   }
 
   /**
-   * Converts this [MastodonAccount] into an [MastodonFollowableProfile].
+   * Converts this [MastodonAccount] into A [MastodonFollowableProfile].
    *
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   [MastodonFollowableProfile]'s avatar will be loaded from a [URL].

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/cache/storage/MastodonProfileEntity.kt
@@ -42,7 +42,7 @@ import java.net.URL
  * @param avatarURL URL [String] that leads to the avatar image.
  * @param bio Describes who the owner is and/or provides information regarding the
  *   [MastodonProfile].
- * @param type Determines whether the [MastodonProfile] is an [MastodonEditableProfile] or an
+ * @param type Determines whether the [MastodonProfile] is A [MastodonEditableProfile] or an
  *   [MastodonFollowableProfile].
  * @param follow [String] version of the [MastodonFollowableProfile]'s
  *   [follow][MastodonFollowableProfile.follow] or `null` if the [MastodonProfile] is of a different
@@ -95,7 +95,7 @@ internal constructor(
   }
 
   /**
-   * Converts this [MastodonProfileEntity] into an [MastodonEditableProfile].
+   * Converts this [MastodonProfileEntity] into A [MastodonEditableProfile].
    *
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   [MastodonEditableProfile]'s avatar will be loaded from a [URL].
@@ -129,7 +129,7 @@ internal constructor(
   }
 
   /**
-   * Converts this [MastodonProfileEntity] into an [MastodonFollowableProfile].
+   * Converts this [MastodonProfileEntity] into A [MastodonFollowableProfile].
    *
    * @param avatarLoaderProvider [ImageLoader.Provider] that provides the [ImageLoader] by which the
    *   [MastodonFollowableProfile]'s avatar will be loaded from a [URL].
@@ -176,10 +176,10 @@ internal constructor(
   }
 
   companion object {
-    /** [Int] that represents an [MastodonEditableProfile]. */
+    /** [Int] that represents A [MastodonEditableProfile]. */
     internal const val EDITABLE_TYPE = 0
 
-    /** [Int] that represents an [MastodonFollowableProfile]. */
+    /** [Int] that represents A [MastodonFollowableProfile]. */
     internal const val FOLLOWABLE_TYPE = 1
   }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/ToggleableStat.extensions.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/ToggleableStat.extensions.kt
@@ -25,7 +25,7 @@ import com.jeanbarrossilva.orca.core.module.instanceProvider
 import com.jeanbarrossilva.orca.std.injector.Injector
 
 /**
- * Builds a [ToggleableStat] for an [MastodonPost]'s favorites that obtains them from the API.
+ * Builds a [ToggleableStat] for A [MastodonPost]'s favorites that obtains them from the API.
  *
  * @param id ID of the [MastodonPost] for which the [ToggleableStat] is.
  * @param count Amount of times that the [MastodonPost] has been marked as favorite.
@@ -48,7 +48,7 @@ internal fun FavoriteStat(id: String, count: Int): ToggleableStat<Profile> {
 }
 
 /**
- * Builds a [ToggleableStat] for an [MastodonPost]'s reblogs that obtains them from the API.
+ * Builds a [ToggleableStat] for A [MastodonPost]'s reblogs that obtains them from the API.
  *
  * @param id ID of the [MastodonPost] for which the [ToggleableStat] is.
  * @param count Amount of times that the [MastodonPost] has been reblogged.

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/Stat.extensions.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/Stat.extensions.kt
@@ -28,7 +28,7 @@ import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.http.Parameters
 
 /**
- * Builds a [Stat] for an [MastodonPost]'s comments that obtains them from the API.
+ * Builds a [Stat] for A [MastodonPost]'s comments that obtains them from the API.
  *
  * @param id ID of the [MastodonPost] for which the [Stat] is.
  * @param count Amount of comments that the [MastodonPost] has received.

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/status/MastodonCard.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/status/MastodonCard.kt
@@ -22,7 +22,7 @@ import java.net.URL
 import kotlinx.serialization.Serializable
 
 /**
- * Structure returned by the API that represents the most prominent content of an [MastodonStatus].
+ * Structure returned by the API that represents the most prominent content of A [MastodonStatus].
  *
  * @param url URL [String] that leads to the webpage to which this [MastodonCard] refers.
  * @param title Title of the webpage.

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/status/MastodonStatus.kt
@@ -35,7 +35,7 @@ import java.time.ZonedDateTime
 import kotlinx.serialization.Serializable
 
 /**
- * Structure returned by the API that is the DTO version of either an [MastodonPost] or a [Repost];
+ * Structure returned by the API that is the DTO version of either A [MastodonPost] or a [Repost];
  * which one it represents is determined by [reblog]'s nullability.
  *
  * @param id Unique identifier.

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/type/editable/MastodonEditor.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/type/editable/MastodonEditor.kt
@@ -63,7 +63,7 @@ internal class MastodonEditor : Editor {
   }
 
   companion object {
-    /** Route to which the [HttpRequest]s will be sent for editing an [MastodonEditableProfile]. */
+    /** Route to which the [HttpRequest]s will be sent for editing A [MastodonEditableProfile]. */
     private const val ROUTE = "api/v1/accounts/update_credentials"
   }
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/instance/MastodonInstance.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/instance/MastodonInstance.kt
@@ -28,7 +28,7 @@ import io.ktor.http.Url
 import io.ktor.http.set
 import io.ktor.http.takeFrom
 
-/** An [MastodonInstance] with a generic [Authorizer] and an [Authenticator]. */
+/** A [MastodonInstance] with a generic [Authorizer] and an [Authenticator]. */
 internal typealias SomeMastodonInstance = MastodonInstance<*, *>
 
 /**


### PR DESCRIPTION
Fixes occurrences of "an" where there should be "a"s.