### PR TITLE
Type-parameterize `KTypeCreator`

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponse.extensions.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponse.extensions.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.javaType
  */
 @Throws(DoubleReceiveException::class, NoTransformationFoundException::class)
 internal suspend fun <T : Any> HttpResponse.body(
-  typeCreator: KTypeCreator,
+  typeCreator: KTypeCreator<T>,
   bodyClass: KClass<T>
 ): T {
   val type = typeCreator.create(bodyClass)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponse.extensions.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponse.extensions.kt
@@ -20,7 +20,6 @@ import io.ktor.client.call.NoTransformationFoundException
 import io.ktor.client.call.body
 import io.ktor.client.statement.HttpResponse
 import io.ktor.util.reflect.TypeInfo
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.javaType
 
@@ -28,17 +27,17 @@ import kotlin.reflect.javaType
  * Receives the payload as being a [T].
  *
  * @param T Body to be obtained.
- * @param typeCreator [KTypeCreator] by which a [KType] for the [bodyClass] will be created.
- * @param bodyClass [KClass] of the body to be returned.
+ * @param typeCreator [KTypeCreator] by which a [KType] for the payload to be returned will be
+ *   created.
  * @throws DoubleReceiveException If the payload has already been received.
  * @throws NoTransformationFoundException If no transformation for [T] is found.
  */
 @Throws(DoubleReceiveException::class, NoTransformationFoundException::class)
-internal suspend fun <T : Any> HttpResponse.body(
-  typeCreator: KTypeCreator<T>,
-  bodyClass: KClass<T>
-): T {
-  val type = typeCreator.create(bodyClass)
-  @OptIn(ExperimentalStdlibApi::class) val typeInfo = TypeInfo(bodyClass, type.javaType, type)
+internal suspend fun <T : Any> HttpResponse.body(typeCreator: KTypeCreator<T>): T {
+  val type = typeCreator.create()
+
+  @OptIn(ExperimentalStdlibApi::class)
+  val typeInfo = TypeInfo(typeCreator.kClass, type.javaType, type)
+
   return body(typeInfo)
 }

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreator.kt
@@ -21,7 +21,7 @@ import kotlin.reflect.KType
 import kotlin.reflect.full.createType
 
 /**
- * Creates a [KType] from a [KClass].
+ * Creates a [KType] from a [KClass] of [T].
  *
  * Such behavior is necessary because of the generic nature of a [MastodonPostPaginator]: since its
  * type parameter (which is the DTO to be received from the API when pagination takes place) cannot
@@ -33,15 +33,16 @@ import kotlin.reflect.full.createType
  * It is primarily taken advantage of by Orca's own implementation of [HttpResponse.body], which
  * takes a [KClass] in instead of a reified type parameter (as does [io.ktor.client.call.body]).
  *
+ * @param T Type whose [KClass] will be used to create a [KType].
  * @see defaultFor
  */
-internal interface KTypeCreator {
+internal interface KTypeCreator<T : Any> {
   /**
    * Creates a [KType] from the [kClass].
    *
    * @param kClass [KClass] for which the [KType] to be created is.
    */
-  fun create(kClass: KClass<*>): KType
+  fun create(kClass: KClass<T>): KType
 
   companion object {
     /**
@@ -62,10 +63,12 @@ internal interface KTypeCreator {
      * **NOTE**: A [ComplexTypeException] will be thrown if [T] is a complex type and a [KType] for
      * a [KClass] of it is requested to be created, denoting that it should be done so manually
      * instead of delegating the creation to a default [KTypeCreator].
+     *
+     * @param T Type whose [KClass] will be used to create a [KType].
      */
-    fun <T : Any> defaultFor(): KTypeCreator {
-      return object : KTypeCreator {
-        override fun create(kClass: KClass<*>): KType {
+    fun <T : Any> defaultFor(): KTypeCreator<T> {
+      return object : KTypeCreator<T> {
+        override fun create(kClass: KClass<T>): KType {
           return try {
             kClass.createType()
           } catch (_: IllegalArgumentException) {

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.flow.onEach
  *
  * @param T DTO that is returned by the API.
  */
-internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator {
+internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator<T> {
   /** Last [HttpResponse] that's been received. */
   private var lastResponse: HttpResponse? = null
 

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonPostPaginator.kt
@@ -27,7 +27,6 @@ import com.jeanbarrossilva.orca.std.injector.Injector
 import io.ktor.client.request.HttpRequest
 import io.ktor.client.statement.HttpResponse
 import kotlin.jvm.optionals.getOrNull
-import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -59,7 +58,7 @@ internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator<T> {
       .map({ (url, isRefreshing) -> isRefreshing || url == null }) { route to it.second }
       .mapNotNull { (url, _) -> url?.let { client.authenticateAndGet(it) } }
       .onEach { lastResponse = it }
-      .map { it.body(this, dtoClass).toMastodonPosts() }
+      .map { it.body(this).toMastodonPosts() }
 
   /** [MastodonClient] through which the [HttpRequest]s will be performed. */
   private val client
@@ -75,9 +74,6 @@ internal abstract class MastodonPostPaginator<T : Any> : KTypeCreator<T> {
 
   /** URL [String] to which the initial [HttpRequest] should be sent. */
   protected abstract val route: String
-
-  /** [KClass] of the DTO that is returned by the API. */
-  protected abstract val dtoClass: KClass<T>
 
   /**
    * Iterates from the current page to the given one.

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
@@ -45,9 +45,9 @@ internal abstract class MastodonStatusesPaginator : MastodonPostPaginator<List<M
   protected abstract val commentPaginatorProvider: MastodonCommentPaginator.Provider
 
   @Suppress("UNCHECKED_CAST")
-  final override val dtoClass = List::class as KClass<List<MastodonStatus>>
+  final override val kClass = List::class as KClass<List<MastodonStatus>>
 
-  final override fun create(kClass: KClass<List<MastodonStatus>>): KType {
+  final override fun create(): KType {
     val statusType = typeOf<MastodonStatus>()
     val statusProjection = KTypeProjection(KVariance.OUT, statusType)
     val arguments = listOf(statusProjection)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/MastodonStatusesPaginator.kt
@@ -47,7 +47,7 @@ internal abstract class MastodonStatusesPaginator : MastodonPostPaginator<List<M
   @Suppress("UNCHECKED_CAST")
   final override val dtoClass = List::class as KClass<List<MastodonStatus>>
 
-  final override fun create(kClass: KClass<*>): KType {
+  final override fun create(kClass: KClass<List<MastodonStatus>>): KType {
     val statusType = typeOf<MastodonStatus>()
     val statusProjection = KTypeProjection(KVariance.OUT, statusType)
     val arguments = listOf(statusProjection)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
@@ -55,7 +55,7 @@ internal class MastodonCommentPaginator(
     fun provide(id: String): MastodonCommentPaginator
   }
 
-  override fun create(kClass: KClass<*>): KType {
+  override fun create(kClass: KClass<MastodonContext>): KType {
     return KTypeCreator.defaultFor<MastodonContext>().create(kClass)
   }
 

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/stat/comment/MastodonCommentPaginator.kt
@@ -23,7 +23,6 @@ import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination.Masto
 import com.jeanbarrossilva.orca.std.image.ImageLoader
 import com.jeanbarrossilva.orca.std.image.SomeImageLoaderProvider
 import java.net.URL
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 /**
@@ -39,8 +38,8 @@ internal class MastodonCommentPaginator(
   private val imageLoaderProvider: SomeImageLoaderProvider<URL>,
   id: String
 ) : MastodonPostPaginator<MastodonContext>() {
+  override val kClass = MastodonContext::class
   override val route = "/api/v1/statuses/$id/context"
-  override val dtoClass = MastodonContext::class
 
   /** Provides a [MastodonProfilePostPaginator] through [provide]. */
   fun interface Provider {
@@ -55,8 +54,8 @@ internal class MastodonCommentPaginator(
     fun provide(id: String): MastodonCommentPaginator
   }
 
-  override fun create(kClass: KClass<MastodonContext>): KType {
-    return KTypeCreator.defaultFor<MastodonContext>().create(kClass)
+  override fun create(): KType {
+    return KTypeCreator.defaultFor<MastodonContext>().create()
   }
 
   override fun MastodonContext.toMastodonPosts(): List<Post> {

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponseExtensionsTests.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/HttpResponseExtensionsTests.kt
@@ -42,7 +42,7 @@ internal class HttpResponseExtensionsTests {
               Logger.test
             )
             .get("/")
-            .body(KTypeCreator.defaultFor<String>(), String::class)
+            .body(KTypeCreator.defaultFor<String>())
         )
         .isEqualTo("Hello, world!")
     }

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreatorTests.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreatorTests.kt
@@ -17,19 +17,17 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import kotlin.reflect.KClass
 import kotlin.reflect.typeOf
 import kotlin.test.Test
 
 internal class KTypeCreatorTests {
   @Test(KTypeCreator.Companion.ComplexTypeException::class)
   fun throwsWhenCreatingComplexTypeWithDefaultCreator() {
-    @Suppress("UNCHECKED_CAST")
-    KTypeCreator.defaultFor<List<Any>>().create(List::class as KClass<List<Any>>)
+    KTypeCreator.defaultFor<List<Any>>().create()
   }
 
   @Test
   fun defaultCreatorCreatesSimpleType() {
-    assertThat(KTypeCreator.defaultFor<String>().create(String::class)).isEqualTo(typeOf<String>())
+    assertThat(KTypeCreator.defaultFor<String>().create()).isEqualTo(typeOf<String>())
   }
 }

--- a/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreatorTests.kt
+++ b/core/mastodon/src/test/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreatorTests.kt
@@ -17,13 +17,15 @@ package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.pagination
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlin.reflect.KClass
 import kotlin.reflect.typeOf
 import kotlin.test.Test
 
 internal class KTypeCreatorTests {
   @Test(KTypeCreator.Companion.ComplexTypeException::class)
   fun throwsWhenCreatingComplexTypeWithDefaultCreator() {
-    KTypeCreator.defaultFor<List<Any>>().create(List::class)
+    @Suppress("UNCHECKED_CAST")
+    KTypeCreator.defaultFor<List<Any>>().create(List::class as KClass<List<Any>>)
   }
 
   @Test


### PR DESCRIPTION
Adds the type from which a [`KTypeCreator`](https://github.com/orcaformastodon/android/blob/0068d4db165e482eb699ca361b2361b1ceb63551/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/pagination/KTypeCreator.kt) creates a [`KType`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.reflect/-k-type) to it as an argument.