### PR TITLE
Turn `Post` into an interface

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/MastodonPost.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/MastodonPost.kt
@@ -52,7 +52,7 @@ internal constructor(
   private val favoriteCount: Int,
   private val reblogCount: Int,
   override val url: URL
-) : Post() {
+) : Post {
   override val comment = CommentStat(id, commentCount, commentPaginatorProvider)
   override val favorite = FavoriteStat(id, favoriteCount)
   override val repost = ReblogStat(id, reblogCount)

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/provider/MastodonPostProvider.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/feed/profile/post/provider/MastodonPostProvider.kt
@@ -13,11 +13,11 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post
+package com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.provider
 
 import com.jeanbarrossilva.orca.core.auth.SomeAuthenticationLock
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.platform.cache.Cache
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf

--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/instance/ContextualMastodonInstance.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/instance/ContextualMastodonInstance.kt
@@ -34,9 +34,9 @@ import com.jeanbarrossilva.orca.core.mastodon.feed.profile.MastodonProfileProvid
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.cache.MastodonProfileFetcher
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.cache.storage.MastodonProfileStorage
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.MastodonPost
-import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.MastodonPostProvider
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.cache.MastodonPostFetcher
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.cache.storage.MastodonPostStorage
+import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.provider.MastodonPostProvider
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.post.stat.comment.MastodonCommentPaginator
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.search.MastodonProfileSearcher
 import com.jeanbarrossilva.orca.core.mastodon.feed.profile.search.cache.MastodonProfileSearchResultsFetcher

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/post/SamplePost.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/post/SamplePost.kt
@@ -40,7 +40,7 @@ internal data class SamplePost(
   override val repost: ToggleableStat<Profile>,
   override val url: URL,
   val writerProvider: SamplePostWriter.Provider
-) : Post() {
+) : Post {
   override val comment = createSampleAddableStat<Post>()
 
   override fun asDeletable(): DeletablePost {

--- a/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/post/SamplePostProvider.kt
+++ b/core/sample/src/main/java/com/jeanbarrossilva/orca/core/sample/feed/profile/post/SamplePostProvider.kt
@@ -17,7 +17,7 @@ package com.jeanbarrossilva.orca.core.sample.feed.profile.post
 
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.core.sample.auth.sample
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/DeletablePost.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/DeletablePost.kt
@@ -22,7 +22,7 @@ package com.jeanbarrossilva.orca.core.feed.profile.post
  *   will be delegated.
  * @see delete
  */
-abstract class DeletablePost(private val delegate: Post) : Post() {
+abstract class DeletablePost(private val delegate: Post) : Post {
   override val id = delegate.id
   override val author = delegate.author
   override val content = delegate.content

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/Post.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/Post.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -15,63 +15,42 @@
 
 package com.jeanbarrossilva.orca.core.feed.profile.post
 
-import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
-import com.jeanbarrossilva.orca.core.auth.SomeAuthenticationLock
-import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.post.content.Content
 import com.jeanbarrossilva.orca.core.feed.profile.post.stat.Stat
 import com.jeanbarrossilva.orca.core.feed.profile.post.stat.addable.AddableStat
 import com.jeanbarrossilva.orca.core.feed.profile.post.stat.toggleable.ToggleableStat
-import java.io.Serializable
 import java.net.URL
 import java.time.ZonedDateTime
 
 /** Content that's been posted by a user, the [author]. */
-abstract class Post : Serializable {
+interface Post {
   /** Unique identifier. */
-  abstract val id: String
+  val id: String
 
   /** [Author] that has authored this [Post]. */
-  abstract val author: Author
+  val author: Author
 
   /** [Content] that's been composed by the [author]. */
-  abstract val content: Content
+  val content: Content
 
   /** Zoned moment in time in which this [Post] was published. */
-  abstract val publicationDateTime: ZonedDateTime
+  val publicationDateTime: ZonedDateTime
 
   /** [Stat] for comments. */
-  abstract val comment: AddableStat<Post>
+  val comment: AddableStat<Post>
 
   /** [Stat] for favorites. */
-  abstract val favorite: ToggleableStat<Profile>
+  val favorite: ToggleableStat<Profile>
 
   /** [Stat] for reposts. */
-  abstract val repost: ToggleableStat<Profile>
+  val repost: ToggleableStat<Profile>
 
   /** [URL] that leads to this [Post]. */
-  abstract val url: URL
+  val url: URL
 
   /** Creates a [DeletablePost] from this [Post]. */
-  abstract fun asDeletable(): DeletablePost
-
-  /**
-   * Creates a [DeletablePost] from this [Post] if its [author] is identified by the
-   * [authenticated][Actor.Authenticated] [Actor]'s ID; otherwise, returns this one.
-   *
-   * @param authenticationLock [AuthenticationLock] by which the ID of the [Actor] will be provided
-   *   and compared to the [author]'s.
-   * @see Actor.Authenticated.id
-   */
-  internal suspend fun asDeletableOrThis(authenticationLock: SomeAuthenticationLock): Post {
-    /**
-     * TODO: Not require the actor to be authenticated in order to return either this post or a
-     *   deletable one from it. May be troublesome when allowing unauthenticated ones to browse
-     *   through the federated feed.
-     */
-    return authenticationLock.scheduleUnlock { if (it.id == author.id) asDeletable() else this }
-  }
+  fun asDeletable(): DeletablePost
 
   companion object
 }

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/provider/Post.extensions.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/provider/Post.extensions.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.feed.profile.post.provider
+
+import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
+import com.jeanbarrossilva.orca.core.auth.SomeAuthenticationLock
+import com.jeanbarrossilva.orca.core.auth.actor.Actor
+import com.jeanbarrossilva.orca.core.feed.profile.post.Author
+import com.jeanbarrossilva.orca.core.feed.profile.post.DeletablePost
+import com.jeanbarrossilva.orca.core.feed.profile.post.Post
+
+/**
+ * Creates a [DeletablePost] from this [Post] if its [Author] is identified by the
+ * [authenticated][Actor.Authenticated] [Actor]'s ID; otherwise, returns this one.
+ *
+ * @param authenticationLock [AuthenticationLock] by which the ID of the [Actor] will be provided
+ *   and compared to the [Author]'s.
+ * @see Post.author
+ * @see Author.id
+ * @see Actor.Authenticated.id
+ */
+internal suspend fun Post.asDeletable(authenticationLock: SomeAuthenticationLock): Post {
+  /**
+   * TODO: Not require the actor to be authenticated in order to return either this post or a
+   *   deletable one from it. May be troublesome when allowing unauthenticated ones to browse
+   *   through the federated feed.
+   */
+  return authenticationLock.scheduleUnlock { if (it.id == author.id) asDeletable() else this }
+}

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/provider/PostProvider.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/provider/PostProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,10 +13,11 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.core.feed.profile.post
+package com.jeanbarrossilva.orca.core.feed.profile.post.provider
 
 import com.jeanbarrossilva.orca.core.auth.AuthenticationLock
 import com.jeanbarrossilva.orca.core.auth.SomeAuthenticationLock
+import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -35,7 +36,7 @@ abstract class PostProvider {
    * @see Post.id
    */
   suspend fun provide(id: String): Flow<Post> {
-    return onProvide(id).map { it.asDeletableOrThis(authenticationLock) }
+    return onProvide(id).map { it.asDeletable(authenticationLock) }
   }
 
   /**

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/repost/Repost.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/repost/Repost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -20,7 +20,7 @@ import com.jeanbarrossilva.orca.core.feed.profile.post.Post
 import java.util.Objects
 
 /** [Post] that has been reposted by someone else. */
-abstract class Repost internal constructor() : Post() {
+abstract class Repost internal constructor() : Post {
   /** [Author] by which this [Repost] has been created. */
   abstract val reposter: Author
 

--- a/core/src/main/java/com/jeanbarrossilva/orca/core/instance/Instance.kt
+++ b/core/src/main/java/com/jeanbarrossilva/orca/core/instance/Instance.kt
@@ -21,7 +21,7 @@ import com.jeanbarrossilva.orca.core.feed.FeedProvider
 import com.jeanbarrossilva.orca.core.feed.profile.Profile
 import com.jeanbarrossilva.orca.core.feed.profile.ProfileProvider
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.core.feed.profile.search.ProfileSearcher
 import com.jeanbarrossilva.orca.core.instance.domain.Domain
 

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/post/DeletablePostTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/post/DeletablePostTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2023-2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -16,11 +16,9 @@
 package com.jeanbarrossilva.orca.core.feed.profile.post
 
 import assertk.assertThat
-import assertk.assertions.isSameAs
 import assertk.assertions.isTrue
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts
 import com.jeanbarrossilva.orca.core.sample.test.feed.profile.post.withSample
-import com.jeanbarrossilva.orca.core.test.TestAuthenticationLock
 import com.jeanbarrossilva.testing.hasPropertiesEqualToThoseOf
 import kotlin.test.Test
 import kotlinx.coroutines.test.runTest
@@ -34,16 +32,6 @@ internal class DeletablePostTests {
         }
       )
       .hasPropertiesEqualToThoseOf(Posts.withSample)
-  }
-
-  @Test
-  fun returnsItselfWhenConvertingItIntoDeletablePost() {
-    val authenticationLock = TestAuthenticationLock()
-    val post =
-      object : DeletablePost(Posts.withSample.single()) {
-        override suspend fun delete() {}
-      }
-    runTest { assertThat(post.asDeletableOrThis(authenticationLock)).isSameAs(post) }
   }
 
   @Test

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/post/provider/PostExtensionsTests.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/post/provider/PostExtensionsTests.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.core.feed.profile.post.provider
+
+import assertk.assertThat
+import assertk.assertions.isSameAs
+import assertk.assertions.isTrue
+import com.jeanbarrossilva.orca.core.feed.profile.post.DeletablePost
+import com.jeanbarrossilva.orca.core.feed.profile.post.Post
+import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts
+import com.jeanbarrossilva.orca.core.sample.test.feed.profile.post.withSample
+import com.jeanbarrossilva.orca.core.test.TestActorProvider
+import com.jeanbarrossilva.orca.core.test.TestAuthenticationLock
+import com.jeanbarrossilva.orca.core.test.TestAuthenticator
+import kotlin.test.Test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+
+internal class PostExtensionsTests {
+  @Test
+  fun schedulesAuthenticationUnlockWhenObtainingDeletableVersionOfPost() {
+    var hasAuthenticationBeenScheduled = false
+    val actorProvider = TestActorProvider()
+    val authenticator =
+      TestAuthenticator(actorProvider = actorProvider) { hasAuthenticationBeenScheduled = true }
+    val authenticationLock = TestAuthenticationLock(actorProvider, authenticator)
+    val post = Posts.withSample.single()
+    runTest {
+      object : PostProvider() {
+          override val authenticationLock = authenticationLock
+
+          override suspend fun onProvide(id: String): Flow<Post> {
+            return flowOf(post)
+          }
+        }
+        .provide(post.id)
+        .first()
+        .asDeletable(authenticationLock)
+    }
+    assertThat(hasAuthenticationBeenScheduled).isTrue()
+  }
+
+  @Test
+  fun returnsItselfWhenMakingDeletablePostDeletable() {
+    val authenticationLock = TestAuthenticationLock()
+    val post =
+      object : DeletablePost(Posts.withSample.single()) {
+        override suspend fun delete() {}
+      }
+    runTest { assertThat(post.asDeletable(authenticationLock)).isSameAs(post) }
+  }
+}

--- a/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/post/test/TestPost.kt
+++ b/core/src/test/java/com/jeanbarrossilva/orca/core/feed/profile/post/test/TestPost.kt
@@ -37,7 +37,7 @@ internal class TestPost(
   override val favorite: ToggleableStat<Profile> = delegate.favorite,
   override val repost: ToggleableStat<Profile> = delegate.repost,
   override val url: URL = delegate.url
-) : Post() {
+) : Post {
   override fun asDeletable(): DeletablePost {
     return delegate.asDeletable()
   }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedModule.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedModule.kt
@@ -16,7 +16,7 @@
 package com.jeanbarrossilva.orca.feature.feed
 
 import com.jeanbarrossilva.orca.core.feed.FeedProvider
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/FeedViewModel.kt
@@ -27,7 +27,7 @@ import com.jeanbarrossilva.orca.composite.timeline.post.PostPreview
 import com.jeanbarrossilva.orca.composite.timeline.post.figure.gallery.disposition.Disposition
 import com.jeanbarrossilva.orca.composite.timeline.post.toPostPreviewFlow
 import com.jeanbarrossilva.orca.core.feed.FeedProvider
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.ext.coroutines.await
 import com.jeanbarrossilva.orca.ext.coroutines.flatMapEach
 import com.jeanbarrossilva.orca.ext.coroutines.notifier.notifierFlow

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryModule.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryModule.kt
@@ -15,7 +15,7 @@
 
 package com.jeanbarrossilva.orca.feature.gallery
 
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module
 import com.jeanbarrossilva.orca.std.injector.module.injection.Injection

--- a/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryViewModel.kt
+++ b/feature/gallery/src/main/java/com/jeanbarrossilva/orca/feature/gallery/GalleryViewModel.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.jeanbarrossilva.orca.composite.timeline.stat.details.asStatsDetailsFlow
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.ext.intents.share
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emitAll

--- a/feature/post-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/postdetails/conversion/TestScope.extensions.kt
+++ b/feature/post-details/src/androidTest/java/com/jeanbarrossilva/orca/feature/postdetails/conversion/TestScope.extensions.kt
@@ -22,7 +22,7 @@ import com.jeanbarrossilva.orca.composite.timeline.post.figure.link.LinkCard
 import com.jeanbarrossilva.orca.composite.timeline.stat.details.StatsDetails
 import com.jeanbarrossilva.orca.core.auth.actor.Actor
 import com.jeanbarrossilva.orca.core.feed.profile.post.Post
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.core.feed.profile.post.stat.Stat
 import com.jeanbarrossilva.orca.core.instance.Instance
 import com.jeanbarrossilva.orca.core.sample.feed.profile.post.Posts

--- a/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsModule.kt
+++ b/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/PostDetailsModule.kt
@@ -15,7 +15,7 @@
 
 package com.jeanbarrossilva.orca.feature.postdetails
 
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module

--- a/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/viewmodel/PostDetailsViewModel.kt
+++ b/feature/post-details/src/main/java/com/jeanbarrossilva/orca/feature/postdetails/viewmodel/PostDetailsViewModel.kt
@@ -24,7 +24,7 @@ import com.jeanbarrossilva.loadable.flow.loadable
 import com.jeanbarrossilva.loadable.list.flow.listLoadable
 import com.jeanbarrossilva.orca.composite.timeline.post.figure.gallery.disposition.Disposition
 import com.jeanbarrossilva.orca.composite.timeline.post.toPostPreview
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.ext.coroutines.await
 import com.jeanbarrossilva.orca.ext.coroutines.mapEach
 import com.jeanbarrossilva.orca.ext.coroutines.notifier.notifierFlow

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsModule.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsModule.kt
@@ -16,7 +16,7 @@
 package com.jeanbarrossilva.orca.feature.profiledetails
 
 import com.jeanbarrossilva.orca.core.feed.profile.ProfileProvider
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.platform.autos.reactivity.OnBottomAreaAvailabilityChangeListener
 import com.jeanbarrossilva.orca.std.injector.module.Inject
 import com.jeanbarrossilva.orca.std.injector.module.Module

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsViewModel.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetailsViewModel.kt
@@ -26,7 +26,7 @@ import com.jeanbarrossilva.orca.composite.timeline.post.PostPreview
 import com.jeanbarrossilva.orca.composite.timeline.post.figure.gallery.disposition.Disposition
 import com.jeanbarrossilva.orca.composite.timeline.post.toPostPreviewFlow
 import com.jeanbarrossilva.orca.core.feed.profile.ProfileProvider
-import com.jeanbarrossilva.orca.core.feed.profile.post.PostProvider
+import com.jeanbarrossilva.orca.core.feed.profile.post.provider.PostProvider
 import com.jeanbarrossilva.orca.ext.coroutines.await
 import com.jeanbarrossilva.orca.ext.coroutines.flatMapEach
 import com.jeanbarrossilva.orca.ext.coroutines.notifier.notifierFlow


### PR DESCRIPTION
The goal is to be able to implement [`Repost`](https://github.com/orcaformastodon/android/blob/25927e4c46170ada90c5cb3752fbbfd60af30476/core/src/main/java/com/jeanbarrossilva/orca/core/feed/profile/post/repost/Repost.kt) rather than creating an instance of it through creator methods.