### PR TITLE
Add `NavigationBar` to `:platform:autos`

### DIFF
--- a/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
+++ b/core/mastodon/src/main/java/com/jeanbarrossilva/orca/core/mastodon/auth/authorization/MastodonAuthorization.kt
@@ -132,7 +132,7 @@ internal fun MastodonAuthorization(
 
   Box(modifier) {
     Scaffold(
-      buttonBar = {
+      bottom = {
         Column(verticalArrangement = Arrangement.spacedBy(ButtonBarDefaults.spacing)) {
           FormTextField(
             domain,
@@ -160,21 +160,27 @@ internal fun MastodonAuthorization(
         }
       }
     ) {
-      LazyColumn(
-        state = lazyListState,
-        contentPadding = it + PaddingValues(spacing),
-        verticalArrangement = Arrangement.spacedBy(AutosTheme.spacings.small.dp)
-      ) {
-        item {
-          Text(
-            stringResource(R.string.core_http_authorization_welcome),
-            textAlign = TextAlign.Center,
-            style = AutosTheme.typography.headlineLarge
-          )
-        }
+      expanded {
+        LazyColumn(
+          state = lazyListState,
+          contentPadding = it + PaddingValues(spacing),
+          verticalArrangement = Arrangement.spacedBy(AutosTheme.spacings.small.dp)
+        ) {
+          item {
+            Text(
+              stringResource(R.string.core_http_authorization_welcome),
+              textAlign = TextAlign.Center,
+              style = AutosTheme.typography.headlineLarge
+            )
+          }
 
-        item {
-          Text(headerTitle, textAlign = TextAlign.Center, style = AutosTheme.typography.titleSmall)
+          item {
+            Text(
+              headerTitle,
+              textAlign = TextAlign.Center,
+              style = AutosTheme.typography.titleSmall
+            )
+          }
         }
       }
     }

--- a/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
+++ b/feature/composer/src/main/java/com/jeanbarrossilva/orca/feature/composer/Composer.kt
@@ -133,60 +133,62 @@ private fun Composer(
       }
     },
     floatingActionButtonPosition = floatingActionButtonPosition
-  ) { padding ->
-    Box(Modifier.padding(padding).fillMaxSize()) {
-      LazyColumn(
-        contentPadding =
-          PaddingValues(bottom = TextFieldDefaults.compositionSpacing) +
-            AutosTheme.overlays.fab.asPaddingValues
-      ) {
-        item {
-          CompositionTextField(
-            value,
-            onValueChange,
-            leadingIcon = { SmallAvatar() },
-            onSend = onCompose,
-            Modifier.onFocusChanged { isToolbarVisible = it.isFocused }
-              .focusRequester(focusRequester)
-          ) {
-            Text(stringResource(R.string.feature_composer_placeholder))
+  ) {
+    navigable { padding ->
+      Box(Modifier.padding(padding).fillMaxSize()) {
+        LazyColumn(
+          contentPadding =
+            PaddingValues(bottom = TextFieldDefaults.compositionSpacing) +
+              AutosTheme.overlays.fab.asPaddingValues
+        ) {
+          item {
+            CompositionTextField(
+              value,
+              onValueChange,
+              leadingIcon = { SmallAvatar() },
+              onSend = onCompose,
+              Modifier.onFocusChanged { isToolbarVisible = it.isFocused }
+                .focusRequester(focusRequester)
+            ) {
+              Text(stringResource(R.string.feature_composer_placeholder))
+            }
           }
         }
-      }
 
-      AnimatedVisibility(
-        isToolbarVisible,
-        Modifier.padding(start = toolbarSpacing, end = toolbarSpacing, bottom = toolbarSpacing)
-          .align(Alignment.BottomStart),
-        enter = slideInVertically { height -> height },
-        exit = fadeOut() + slideOutVertically { height -> height }
-      ) {
-        /*
-         * There is a bug where the EditProcessor used by CoreTextField's state under the
-         * hood creates a new instance of the AnnotatedString held by the TextFieldValue
-         * (whenever selection changes) only with its text property set, ignoring any span
-         * or paragraph styles given in the previous recomposition.
-         *
-         * This is an issue known since 2019, so I don't know how likely it is that the
-         * Compose team is going to fix it any time soon. Multi-style text editing has been
-         * on the roadmap since October 2022.
-         *
-         * https://issuetracker.google.com/issues/199754661
-         * https://developer.android.com/jetpack/androidx/compose-roadmap
-         */
-        Toolbar(
-          value.isSelectionBold,
-          onBoldToggle = { isBold -> onValueChange(value.withBoldSelection(isBold)) },
-          value.isSelectionItalicized,
-          onItalicToggle = { isItalicized ->
-            onValueChange(value.withItalicizedSelection(isItalicized))
-          },
-          value.isSelectionUnderlined,
-          onUnderlineToggle = { isUnderlined ->
-            onValueChange(value.withUnderlinedSelection(isUnderlined))
-          },
-          Modifier.padding(toolbarSafeAreaPadding)
-        )
+        AnimatedVisibility(
+          isToolbarVisible,
+          Modifier.padding(start = toolbarSpacing, end = toolbarSpacing, bottom = toolbarSpacing)
+            .align(Alignment.BottomStart),
+          enter = slideInVertically { height -> height },
+          exit = fadeOut() + slideOutVertically { height -> height }
+        ) {
+          /*
+           * There is a bug where the EditProcessor used by CoreTextField's state under the
+           * hood creates a new instance of the AnnotatedString held by the TextFieldValue
+           * (whenever selection changes) only with its text property set, ignoring any span
+           * or paragraph styles given in the previous recomposition.
+           *
+           * This is an issue known since 2019, so I don't know how likely it is that the
+           * Compose team is going to fix it any time soon. Multi-style text editing has been
+           * on the roadmap since October 2022.
+           *
+           * https://issuetracker.google.com/issues/199754661
+           * https://developer.android.com/jetpack/androidx/compose-roadmap
+           */
+          Toolbar(
+            value.isSelectionBold,
+            onBoldToggle = { isBold -> onValueChange(value.withBoldSelection(isBold)) },
+            value.isSelectionItalicized,
+            onItalicToggle = { isItalicized ->
+              onValueChange(value.withItalicizedSelection(isItalicized))
+            },
+            value.isSelectionUnderlined,
+            onUnderlineToggle = { isUnderlined ->
+              onValueChange(value.withUnderlinedSelection(isUnderlined))
+            },
+            Modifier.padding(toolbarSafeAreaPadding)
+          )
+        }
       }
     }
   }

--- a/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
+++ b/feature/feed/src/main/java/com/jeanbarrossilva/orca/feature/feed/Feed.kt
@@ -162,19 +162,25 @@ private fun Feed(
       }
     }
   ) {
-    Timeline(
-      postPreviewsLoadable,
-      onFavorite,
-      onRepost,
-      onShare,
-      onPostClick,
-      onNext,
-      Modifier.nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
-        .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-      contentPadding = it + AutosTheme.overlays.fab.asPaddingValues,
-      refresh =
-        Refresh(isTimelineRefreshing, indicatorOffset = it.calculateTopPadding(), onTimelineRefresh)
-    )
+    navigable {
+      Timeline(
+        postPreviewsLoadable,
+        onFavorite,
+        onRepost,
+        onShare,
+        onPostClick,
+        onNext,
+        Modifier.nestedScroll(bottomAreaAvailabilityNestedScrollConnection)
+          .nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+        contentPadding = it + AutosTheme.overlays.fab.asPaddingValues,
+        refresh =
+          Refresh(
+            isTimelineRefreshing,
+            indicatorOffset = it.calculateTopPadding(),
+            onTimelineRefresh
+          )
+      )
+    }
   }
 }
 

--- a/feature/gallery-test/build.gradle.kts
+++ b/feature/gallery-test/build.gradle.kts
@@ -33,10 +33,10 @@ dependencies {
   implementation(project(":composite:timeline"))
   implementation(project(":feature:gallery"))
   implementation(project(":platform:autos"))
+  implementation(project(":platform:autos-test"))
   implementation(project(":platform:testing"))
   implementation(libs.android.compose.ui.test.junit)
   implementation(libs.android.compose.ui.test.manifest)
-  implementation(libs.android.test.espresso.core)
   implementation(libs.loadable.placeholder.test)
 }
 

--- a/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsMatcher.extensions.kt
+++ b/feature/gallery-test/src/main/java/com/jeanbarrossilva/orca/feature/gallery/test/ui/SemanticsMatcher.extensions.kt
@@ -16,108 +16,13 @@
 package com.jeanbarrossilva.orca.feature.gallery.test.ui
 
 import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.layout.LayoutInfo
-import androidx.compose.ui.platform.ViewRootForTest
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.hasTestTag
-import androidx.compose.ui.test.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers
 import com.jeanbarrossilva.orca.feature.gallery.ui.GALLERY_PAGER_TAG
 import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
-
-/**
- * [SemanticsMatcher] that matches a displayed [SemanticsNode].
- *
- * **NOTE**: Most of the implementation is as [SemanticsNodeInteraction.isDisplayed]'s is, since no
- * version of it has been made publicly available specifically for strictly-assertion-driven
- * scenarios (such as an `isDisplayed()` [SemanticsMatcher] like this one) as of version 1.5.3 of
- * Jetpack Compose. If it is to be officially provided in an adopted future version, it is highly
- * recommended to migrate to it instead of relying on this one.
- */
-@Suppress("VisibleForTests")
-fun isDisplayed(): SemanticsMatcher {
-  return SemanticsMatcher("is displayed") { node ->
-    fun isNotPlaced(layoutInfo: LayoutInfo): Boolean {
-      return !layoutInfo.isPlaced
-    }
-
-    fun clippedNodeBoundsInWindow(): Rect {
-      val composeView = (node.root as ViewRootForTest).view
-      val rootLocationInWindow =
-        intArrayOf(0, 0).let { location ->
-          composeView.getLocationInWindow(location)
-          Offset(location[0].toFloat(), location[1].toFloat())
-        }
-      return node.boundsInRoot.translate(rootLocationInWindow)
-    }
-
-    fun isNodeInScreenBounds(): Boolean {
-      val composeView = (node.root as ViewRootForTest).view
-
-      // Window relative bounds of our node
-      val nodeBoundsInWindow = clippedNodeBoundsInWindow()
-      if (nodeBoundsInWindow.width == 0f || nodeBoundsInWindow.height == 0f) {
-        return false
-      }
-
-      // Window relative bounds of our compose root view that are visible on the screen
-      val globalRootRect = android.graphics.Rect()
-      if (!composeView.getGlobalVisibleRect(globalRootRect)) {
-        return false
-      }
-      return !nodeBoundsInWindow
-        .intersect(
-          Rect(
-            globalRootRect.left.toFloat(),
-            globalRootRect.top.toFloat(),
-            globalRootRect.right.toFloat(),
-            globalRootRect.bottom.toFloat()
-          )
-        )
-        .isEmpty
-    }
-
-    /**
-     * Returns the closest [LayoutInfo] that hasn't been placed or `null` if all of the [node]'s
-     * parents have been placed.
-     */
-    fun findClosestUnplacedParentNode(): LayoutInfo? {
-      var currentParent = node.layoutInfo.parentInfo
-      while (currentParent != null) {
-        if (isNotPlaced(currentParent)) {
-          return currentParent
-        } else {
-          currentParent = currentParent.parentInfo
-        }
-      }
-
-      return null
-    }
-
-    if (isNotPlaced(node.layoutInfo) || findClosestUnplacedParentNode() != null) {
-      return@SemanticsMatcher false
-    }
-    (node.root as? ViewRootForTest)?.let { root ->
-      if (!ViewMatchers.isDisplayed().matches(root.view)) {
-        return@SemanticsMatcher false
-      }
-    }
-
-    // check node doesn't clip unintentionally (e.g. row too small for content)
-    val globalRect = node.boundsInWindow
-    if (!isNodeInScreenBounds()) {
-      return@SemanticsMatcher false
-    }
-    globalRect.width > 0f && globalRect.height > 0f
-  }
-}
 
 /** [SemanticsMatcher] that matches a [Gallery]'s [HorizontalPager]. */
 fun isPager(): SemanticsMatcher {

--- a/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
+++ b/feature/profile-details/src/main/java/com/jeanbarrossilva/orca/feature/profiledetails/ProfileDetails.kt
@@ -498,7 +498,9 @@ private fun ProfileDetails(
   }
 
   Box(modifier) {
-    Scaffold(floatingActionButton = floatingActionButton) { timeline(isHeaderHidden, it) }
+    Scaffold(floatingActionButton = floatingActionButton) {
+      navigable { timeline(isHeaderHidden, it) }
+    }
 
     AnimatedVisibility(
       visible = isHeaderHidden,

--- a/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
+++ b/feature/search/src/main/java/com/jeanbarrossilva/orca/feature/search/Search.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -184,18 +183,19 @@ private fun Search(
       }
     }
   ) {
-    LazyColumn(
-      @OptIn(ExperimentalLayoutApi::class)
-      Modifier
-        // TODO: Add bottom bar overlay to Overlays.
-        .consumeWindowInsets(PaddingValues(104.dp))
-        .imePadding()
-        .fillMaxSize(),
-      verticalArrangement = verticalArrangement,
-      horizontalAlignment = horizontalAlignment,
-      contentPadding = it,
-      content = content
-    )
+    expanded {
+      LazyColumn(
+        Modifier
+          // TODO: Add bottom bar overlay to Overlays.
+          .consumeWindowInsets(PaddingValues(104.dp))
+          .imePadding()
+          .fillMaxSize(),
+        verticalArrangement = verticalArrangement,
+        horizontalAlignment = horizontalAlignment,
+        contentPadding = it,
+        content = content
+      )
+    }
   }
 }
 

--- a/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/Settings.kt
+++ b/feature/settings/src/main/java/com/jeanbarrossilva/orca/feature/settings/Settings.kt
@@ -71,14 +71,16 @@ private fun Settings(
       )
     }
   ) {
-    LazyColumn(
-      Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-      state = lazyListState,
-      contentPadding = it + PaddingValues(AutosTheme.spacings.medium.dp)
-    ) {
-      item {
-        Section(stringResource(R.string.feature_settings_general)) {
-          muting(mutedTerms, onNavigationToTermMuting, onTermUnmute)
+    navigable {
+      LazyColumn(
+        Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+        state = lazyListState,
+        contentPadding = it + PaddingValues(AutosTheme.spacings.medium.dp)
+      ) {
+        item {
+          Section(stringResource(R.string.feature_settings_general)) {
+            muting(mutedTerms, onNavigationToTermMuting, onTermUnmute)
+          }
         }
       }
     }

--- a/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
+++ b/feature/settings/term-muting/src/main/java/com/jeanbarrossilva/orca/feature/settings/termmuting/TermMuting.kt
@@ -111,7 +111,7 @@ internal fun TermMuting(
         scrollBehavior = topAppBarScrollBehavior
       )
     },
-    buttonBar = {
+    bottom = {
       ButtonBar(lazyListState) {
         PrimaryButton(onClick = onDone, Modifier.testTag(SETTINGS_TERM_MUTING_MUTE_BUTTON)) {
           Text(stringResource(R.string.feature_settings_term_muting_mute))
@@ -119,32 +119,34 @@ internal fun TermMuting(
       }
     }
   ) {
-    LazyColumn(
-      Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
-      lazyListState,
-      verticalArrangement = Arrangement.spacedBy(spacing),
-      contentPadding = it + PaddingValues(spacing)
-    ) {
-      item {
-        FormTextField(
-          term,
-          onTermChange,
-          Modifier.focusRequester(focusRequester)
-            .fillMaxWidth()
-            .testTag(SETTINGS_TERM_MUTING_TEXT_FIELD_TAG),
-          errorDispatcher,
-          KeyboardOptions(imeAction = ImeAction.Done),
-          KeyboardActions(onDone = { onDone() })
-        ) {
-          Text(stringResource(R.string.feature_settings_term_muting_term))
+    navigable {
+      LazyColumn(
+        Modifier.nestedScroll(topAppBarScrollBehavior.nestedScrollConnection),
+        lazyListState,
+        verticalArrangement = Arrangement.spacedBy(spacing),
+        contentPadding = it + PaddingValues(spacing)
+      ) {
+        item {
+          FormTextField(
+            term,
+            onTermChange,
+            Modifier.focusRequester(focusRequester)
+              .fillMaxWidth()
+              .testTag(SETTINGS_TERM_MUTING_TEXT_FIELD_TAG),
+            errorDispatcher,
+            KeyboardOptions(imeAction = ImeAction.Done),
+            KeyboardActions(onDone = { onDone() })
+          ) {
+            Text(stringResource(R.string.feature_settings_term_muting_term))
+          }
         }
-      }
 
-      item {
-        Text(
-          stringResource(R.string.feature_settings_term_muting_explanation),
-          style = AutosTheme.typography.bodySmall
-        )
+        item {
+          Text(
+            stringResource(R.string.feature_settings_term_muting_explanation),
+            style = AutosTheme.typography.bodySmall
+          )
+        }
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ android-compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test
 android-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "android-compose" }
 android-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "android-compose" }
 android-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.1.4" }
-android-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version = "1.0.1" }
 android-core = { group = "androidx.core", name = "core-ktx", version = "1.12.0" }
 android-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "android-fragment" }
 android-fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "android-fragment" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ android-compose-ui-test-junit = { group = "androidx.compose.ui", name = "ui-test
 android-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "android-compose" }
 android-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "android-compose" }
 android-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.1.4" }
+android-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version = "1.0.1" }
 android-core = { group = "androidx.core", name = "core-ktx", version = "1.12.0" }
 android-fragment-ktx = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "android-fragment" }
 android-fragment-testing = { group = "androidx.fragment", name = "fragment-testing", version.ref = "android-fragment" }

--- a/platform/autos-test/build.gradle.kts
+++ b/platform/autos-test/build.gradle.kts
@@ -33,4 +33,5 @@ dependencies {
 
   implementation(project(":platform:autos"))
   implementation(libs.android.compose.ui.test.junit)
+  implementation(libs.android.test.espresso.core)
 }

--- a/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/SemanticsMatcherExtensionsTests.kt
+++ b/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/SemanticsMatcherExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,18 +13,20 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-@file:JvmName("CornerBasedShapes")
+package com.jeanbarrossilva.orca.platform.autos.test
 
-package com.jeanbarrossilva.orca.platform.autos.kit
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import org.junit.Rule
+import org.junit.Test
 
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.foundation.shape.ZeroCornerSize
+internal class SemanticsMatcherExtensionsTests {
+  @get:Rule val composeRule = createComposeRule()
 
-/** Version of this [CornerBasedShape] with zeroed top [CornerSize]s. */
-internal val CornerBasedShape.bottom
-  get() = copy(topStart = ZeroCornerSize, topEnd = ZeroCornerSize)
-
-/** Version of this [CornerBasedShape] with zeroed bottom [CornerSize]s. */
-internal val CornerBasedShape.top
-  get() = copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize)
+  @Test
+  fun matchesDisplayedNode() {
+    composeRule.apply { setContent { Text("Hello, world!") } }.onRoot().assert(isDisplayed())
+  }
+}

--- a/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsMatcherExtensionsTests.kt
+++ b/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsMatcherExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,16 +13,11 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.test.ui
+package com.jeanbarrossilva.orca.platform.autos.test.kit.scaffold.bar.navigation
 
-import androidx.compose.foundation.Image
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChildren
-import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.isPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test
@@ -31,35 +26,22 @@ internal class SemanticsMatcherExtensionsTests {
   @get:Rule val composeRule = createComposeRule()
 
   @Test
-  fun matchesImage() {
+  fun matchesNavigationBar() {
+    composeRule
+      .apply { setContent { AutosTheme { NavigationBar(title = {}, action = {}) {} } } }
+      .onNode(isNavigationBar())
+      .assertIsDisplayed()
+  }
+
+  @Test
+  fun matchesTab() {
     composeRule
       .apply {
         setContent {
-          Image(
-            painterResource(com.jeanbarrossilva.orca.std.image.compose.R.drawable.image),
-            contentDescription = "Image"
-          )
+          AutosTheme { NavigationBar(title = {}, action = {}) { tab(onClick = {}) {} } }
         }
       }
-      .onNode(isImage())
-      .assertIsDisplayed()
-  }
-
-  @Test
-  fun matchesPager() {
-    composeRule
-      .apply { setContent { AutosTheme { Gallery() } } }
-      .onNode(isPager())
-      .assertIsDisplayed()
-  }
-
-  @Test
-  fun matchesPage() {
-    composeRule
-      .apply { setContent { AutosTheme { Gallery() } } }
-      .onPager()
-      .onChildren()
-      .filterToOne(isPage())
+      .onNode(isTab())
       .assertIsDisplayed()
   }
 }

--- a/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsNodeInteractionsProviderExtensionsTests.kt
+++ b/platform/autos-test/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsNodeInteractionsProviderExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023-2024 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,53 +13,49 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.test.ui
+package com.jeanbarrossilva.orca.platform.autos.test.kit.scaffold.bar.navigation
 
-import androidx.compose.foundation.Image
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.test.assertAll
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.filterToOne
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onChildren
-import com.jeanbarrossilva.orca.feature.gallery.test.ui.page.isPage
-import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
+import com.jeanbarrossilva.orca.platform.autos.test.isDisplayed
 import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
 import org.junit.Rule
 import org.junit.Test
 
-internal class SemanticsMatcherExtensionsTests {
+internal class SemanticsNodeInteractionsProviderExtensionsTests {
   @get:Rule val composeRule = createComposeRule()
 
   @Test
-  fun matchesImage() {
+  fun findsNavigationBar() {
+    composeRule
+      .apply { setContent { AutosTheme { NavigationBar(title = {}, action = {}) {} } } }
+      .onNavigationBar()
+      .assertIsDisplayed()
+  }
+
+  @Test
+  fun findsTab() {
     composeRule
       .apply {
         setContent {
-          Image(
-            painterResource(com.jeanbarrossilva.orca.std.image.compose.R.drawable.image),
-            contentDescription = "Image"
-          )
+          AutosTheme { NavigationBar(title = {}, action = {}) { tab(onClick = {}) {} } }
         }
       }
-      .onNode(isImage())
+      .onTab()
       .assertIsDisplayed()
   }
 
   @Test
-  fun matchesPager() {
+  fun findsTabs() {
     composeRule
-      .apply { setContent { AutosTheme { Gallery() } } }
-      .onNode(isPager())
-      .assertIsDisplayed()
-  }
-
-  @Test
-  fun matchesPage() {
-    composeRule
-      .apply { setContent { AutosTheme { Gallery() } } }
-      .onPager()
-      .onChildren()
-      .filterToOne(isPage())
-      .assertIsDisplayed()
+      .apply {
+        setContent {
+          AutosTheme { NavigationBar(title = {}, action = {}) { tab(onClick = {}) {} } }
+        }
+      }
+      .onTabs()
+      .assertAll(isDisplayed())
   }
 }

--- a/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/SemanticsMatcher.extensions.kt
+++ b/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/SemanticsMatcher.extensions.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.test
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.layout.LayoutInfo
+import androidx.compose.ui.platform.ViewRootForTest
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers
+
+/**
+ * [SemanticsMatcher] that matches a displayed [SemanticsNode].
+ *
+ * **NOTE**: Most of the implementation is as [SemanticsNodeInteraction.isDisplayed]'s is, since no
+ * version of it has been made publicly available specifically for strictly-assertion-driven
+ * scenarios (such as an `isDisplayed()` [SemanticsMatcher] like this one) as of version 1.5.3 of
+ * Jetpack Compose. If it is to be officially provided in an adopted future version, it is highly
+ * recommended to migrate to it instead of relying on this one.
+ */
+@Suppress("VisibleForTests")
+fun isDisplayed(): SemanticsMatcher {
+  return SemanticsMatcher("is displayed") { node ->
+    fun isNotPlaced(layoutInfo: LayoutInfo): Boolean {
+      return !layoutInfo.isPlaced
+    }
+
+    fun clippedNodeBoundsInWindow(): Rect {
+      val composeView = (node.root as ViewRootForTest).view
+      val rootLocationInWindow =
+        intArrayOf(0, 0).let { location ->
+          composeView.getLocationInWindow(location)
+          Offset(location[0].toFloat(), location[1].toFloat())
+        }
+      return node.boundsInRoot.translate(rootLocationInWindow)
+    }
+
+    fun isNodeInScreenBounds(): Boolean {
+      val composeView = (node.root as ViewRootForTest).view
+
+      // Window relative bounds of our node
+      val nodeBoundsInWindow = clippedNodeBoundsInWindow()
+      if (nodeBoundsInWindow.width == 0f || nodeBoundsInWindow.height == 0f) {
+        return false
+      }
+
+      // Window relative bounds of our compose root view that are visible on the screen
+      val globalRootRect = android.graphics.Rect()
+      if (!composeView.getGlobalVisibleRect(globalRootRect)) {
+        return false
+      }
+      return !nodeBoundsInWindow
+        .intersect(
+          Rect(
+            globalRootRect.left.toFloat(),
+            globalRootRect.top.toFloat(),
+            globalRootRect.right.toFloat(),
+            globalRootRect.bottom.toFloat()
+          )
+        )
+        .isEmpty
+    }
+
+    /**
+     * Returns the closest [LayoutInfo] that hasn't been placed or `null` if all of the [node]'s
+     * parents have been placed.
+     */
+    /**
+     * Returns the closest [LayoutInfo] that hasn't been placed or `null` if all of the [node]'s
+     * parents have been placed.
+     */
+    fun findClosestUnplacedParentNode(): LayoutInfo? {
+      var currentParent = node.layoutInfo.parentInfo
+      while (currentParent != null) {
+        if (isNotPlaced(currentParent)) {
+          return currentParent
+        } else {
+          currentParent = currentParent.parentInfo
+        }
+      }
+
+      return null
+    }
+
+    if (isNotPlaced(node.layoutInfo) || findClosestUnplacedParentNode() != null) {
+      return@SemanticsMatcher false
+    }
+    (node.root as? ViewRootForTest)?.let { root ->
+      if (!ViewMatchers.isDisplayed().matches(root.view)) {
+        return@SemanticsMatcher false
+      }
+    }
+
+    // check node doesn't clip unintentionally (e.g. row too small for content)
+    val globalRect = node.boundsInWindow
+    if (!isNodeInScreenBounds()) {
+      return@SemanticsMatcher false
+    }
+    globalRect.width > 0f && globalRect.height > 0f
+  }
+}

--- a/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsMatcher.extensions.kt
+++ b/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsMatcher.extensions.kt
@@ -13,21 +13,24 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-package com.jeanbarrossilva.orca.feature.gallery.test.ui.page
+package com.jeanbarrossilva.orca.platform.autos.test.kit.scaffold.bar.navigation
 
-import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.ui.test.SemanticsMatcher
-import androidx.compose.ui.test.hasParent
-import com.jeanbarrossilva.orca.feature.gallery.test.ui.isImage
-import com.jeanbarrossilva.orca.feature.gallery.test.ui.isPager
-import com.jeanbarrossilva.orca.feature.gallery.ui.Gallery
-import com.jeanbarrossilva.orca.platform.autos.test.isDisplayed
+import androidx.compose.ui.test.hasTestTag
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NAVIGATION_BAR_TAG
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBarScope
+
+/** [SemanticsMatcher] that matches a [NavigationBar]. */
+fun isNavigationBar(): SemanticsMatcher {
+  return hasTestTag(NAVIGATION_BAR_TAG)
+}
 
 /**
- * [SemanticsMatcher] that matches a [Gallery]'s [HorizontalPager]'s current page.
+ * [SemanticsMatcher] that matches a tab of a [NavigationBar].
  *
- * @see isPager
+ * @see isNavigationBar
  */
-fun isPage(): SemanticsMatcher {
-  return hasParent(isPager()) and isDisplayed() and isImage()
+fun isTab(): SemanticsMatcher {
+  return hasTestTag(NavigationBarScope.TAB_TAG)
 }

--- a/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsNodeInteractionsProvider.extensions.kt
+++ b/platform/autos-test/src/main/java/com/jeanbarrossilva/orca/platform/autos/test/kit/scaffold/bar/navigation/SemanticsNodeInteractionsProvider.extensions.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.test.kit.scaffold.bar.navigation
+
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBarScope
+
+/** [SemanticsNodeInteraction] of a [NavigationBar]. */
+fun SemanticsNodeInteractionsProvider.onNavigationBar(): SemanticsNodeInteraction {
+  return onNode(isNavigationBar())
+}
+
+/**
+ * [SemanticsNodeInteraction] of a [NavigationBar]'s tab.
+ *
+ * @see isNavigationBar
+ * @see SemanticsNodeInteractionsProvider.onNavigationBar
+ * @see NavigationBarScope.tab
+ * @see isTab
+ */
+fun SemanticsNodeInteractionsProvider.onTab(): SemanticsNodeInteraction {
+  return onNode(isTab())
+}
+
+/**
+ * [SemanticsNodeInteractionCollection] of a [NavigationBar]'s tabs.
+ *
+ * @see isNavigationBar
+ * @see SemanticsNodeInteractionsProvider.onNavigationBar
+ * @see NavigationBarScope.tab
+ * @see isTab
+ */
+fun SemanticsNodeInteractionsProvider.onTabs(): SemanticsNodeInteractionCollection {
+  return onAllNodes(isTab())
+}

--- a/platform/autos/build.gradle.kts
+++ b/platform/autos/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
   implementation(project(":ext:coroutines"))
   implementation(project(":ext:reflection"))
   implementation(libs.accompanist.adapter)
-  implementation(libs.android.constraintlayout.compose)
   implementation(libs.android.material)
   implementation(libs.kotlin.reflect)
   implementation(libs.loadable.placeholder)

--- a/platform/autos/build.gradle.kts
+++ b/platform/autos/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
   implementation(project(":ext:coroutines"))
   implementation(project(":ext:reflection"))
   implementation(libs.accompanist.adapter)
+  implementation(libs.android.constraintlayout.compose)
   implementation(libs.android.material)
   implementation(libs.kotlin.reflect)
   implementation(libs.loadable.placeholder)

--- a/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/button/ButtonBarTests.kt
+++ b/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/button/ButtonBarTests.kt
@@ -38,8 +38,8 @@ internal class ButtonBarTests {
     val lazyListState = LazyListState()
     composeRule.setContent {
       AutosTheme {
-        Scaffold(buttonBar = { ButtonBar(lazyListState) }) {
-          LazyColumn(state = lazyListState) { item { Spacer(Modifier) } }
+        Scaffold(bottom = { ButtonBar(lazyListState) }) {
+          expanded { LazyColumn(state = lazyListState) { item { Spacer(Modifier) } } }
         }
       }
     }
@@ -51,9 +51,11 @@ internal class ButtonBarTests {
     val lazyListState = LazyListState()
     composeRule.setContent {
       AutosTheme {
-        Scaffold(buttonBar = { ButtonBar(lazyListState) }) {
-          LazyColumn(state = lazyListState) {
-            item { Spacer(Modifier.padding(it).fillScreenSize()) }
+        Scaffold(bottom = { ButtonBar(lazyListState) }) {
+          expanded {
+            LazyColumn(state = lazyListState) {
+              item { Spacer(Modifier.padding(it).fillScreenSize()) }
+            }
           }
         }
       }

--- a/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBarTests.kt
+++ b/platform/autos/src/androidTest/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBarTests.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import assertk.assertThat
+import assertk.assertions.isTrue
+import com.jeanbarrossilva.orca.platform.autos.test.kit.scaffold.bar.navigation.onTab
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import kotlin.test.Test
+import org.junit.Rule
+
+internal class NavigationBarTests {
+  @get:Rule val composeRule = createComposeRule()
+
+  @Test
+  fun notifiesOfClickOnTab() {
+    var hasTabBeenClicked = false
+    composeRule
+      .apply {
+        setContent {
+          AutosTheme {
+            NavigationBar(title = {}, action = {}) {
+              tab(onClick = { hasTabBeenClicked = true }) {}
+            }
+          }
+        }
+      }
+      .onTab()
+      .performClick()
+    assertThat(hasTabBeenClicked).isTrue()
+  }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/forms/Form.extensions.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/forms/Form.extensions.kt
@@ -13,6 +13,8 @@
  * not, see https://www.gnu.org/licenses.
  */
 
+@file:JvmName("Forms")
+
 package com.jeanbarrossilva.orca.platform.autos.forms
 
 import androidx.compose.foundation.shape.CornerBasedShape

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/Scaffold.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/Scaffold.kt
@@ -16,7 +16,6 @@
 package com.jeanbarrossilva.orca.platform.autos.kit.scaffold
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -31,6 +30,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.takeOrElse
@@ -40,11 +40,14 @@ import com.jeanbarrossilva.orca.platform.autos.forms.asShape
 import com.jeanbarrossilva.orca.platform.autos.iconography.asImageVector
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.Scaffold as _Scaffold
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.button.ButtonBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.snack.orcaVisuals
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.snack.presenter.SnackbarPresenter
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.snack.presenter.rememberSnackbarPresenter
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.TopAppBar
 import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.scope.Content
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.scope.ScaffoldScope
 import com.jeanbarrossilva.orca.platform.autos.kit.sheet.LocalWindowInsets
 import com.jeanbarrossilva.orca.platform.autos.kit.sheet.takeOrElse
 import com.jeanbarrossilva.orca.platform.autos.overlays.asPaddingValues
@@ -56,13 +59,16 @@ import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
  *
  * @param modifier [Modifier] to be applied to the underlying [Scaffold].
  * @param topAppBar [TopAppBar] to be placed at the top.
- * @param floatingActionButton [FloatingActionButton] to be placed at the bottom, above the
- *   [buttonBar] and below the [SnackbarHost], horizontally centered.
+ * @param floatingActionButton [FloatingActionButton] to be placed at the bottom, above the [bottom]
+ *   and below the [SnackbarHost], horizontally centered.
  * @param floatingActionButtonPosition [FabPosition] that determines where the
  *   [floatingActionButton] will be placed.
  * @param snackbarPresenter [SnackbarPresenter] through which [Snackbar]s can be presented.
- * @param buttonBar [ButtonBar] to be placed at the utmost bottom.
+ * @param bottom [Composable] to be placed at the utmost bottom, such as a [NavigationBar] and/or a
+ *   [ButtonBar].
  * @param content Main content of the current context.
+ * @see ScaffoldScope.expanded
+ * @see ScaffoldScope.navigable
  */
 @Composable
 fun Scaffold(
@@ -71,13 +77,13 @@ fun Scaffold(
   floatingActionButton: @Composable () -> Unit = {},
   floatingActionButtonPosition: FabPosition = FabPosition.End,
   snackbarPresenter: SnackbarPresenter = rememberSnackbarPresenter(),
-  buttonBar: @Composable () -> Unit = {},
-  content: @Composable (padding: PaddingValues) -> Unit
+  bottom: @Composable () -> Unit = {},
+  content: ScaffoldScope.() -> Content
 ) {
   Scaffold(
     modifier,
     topAppBar,
-    bottomBar = buttonBar,
+    bottomBar = bottom,
     snackbarHost = {
       SnackbarHost(snackbarPresenter.hostState) {
         Snackbar(
@@ -92,9 +98,10 @@ fun Scaffold(
     floatingActionButtonPosition,
     LocalContainerColor.current.takeOrElse { AutosTheme.colors.background.container.asColor },
     contentWindowInsets =
-      LocalWindowInsets.current.takeOrElse { ScaffoldDefaults.contentWindowInsets },
-    content = content
-  )
+      LocalWindowInsets.current.takeOrElse { ScaffoldDefaults.contentWindowInsets }
+  ) {
+    remember(::ScaffoldScope).content().ClippedValue(it)
+  }
 }
 
 /** Preview of a [Scaffold][_Scaffold]. */
@@ -120,16 +127,18 @@ private fun ScaffoldPreview() {
         }
       },
       snackbarPresenter = snackbarPresenter,
-      buttonBar = { ButtonBar(lazyListState) }
+      bottom = { ButtonBar(lazyListState) }
     ) {
-      LazyColumn(
-        Modifier.fillMaxSize(),
-        state = lazyListState,
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        contentPadding = it + AutosTheme.overlays.fab.asPaddingValues
-      ) {
-        item { Text("Content", style = AutosTheme.typography.bodyMedium) }
+      expanded {
+        LazyColumn(
+          Modifier.fillMaxSize(),
+          state = lazyListState,
+          verticalArrangement = Arrangement.Center,
+          horizontalAlignment = Alignment.CenterHorizontally,
+          contentPadding = it + AutosTheme.overlays.fab.asPaddingValues
+        ) {
+          item { Text("Content", style = AutosTheme.typography.bodyMedium) }
+        }
       }
     }
   }

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBar.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBar.kt
@@ -16,7 +16,6 @@
 package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -55,6 +54,7 @@ object NavigationBarDefaults {
  * @param title [AutoSizeText] that describes the current context.
  * @param action Main navigation action.
  * @param modifier [Modifier] to be applied to the underlying [Surface].
+ * @param subtitle [AutoSizeText] for more details on the current context.
  * @param content Tabs that are shown, configured through the provided [NavigationBarScope].
  * @see NavigationBarScope.tab
  */
@@ -63,6 +63,7 @@ fun NavigationBar(
   title: @Composable () -> Unit,
   action: @Composable () -> Unit,
   modifier: Modifier = Modifier,
+  subtitle: @Composable () -> Unit = {},
   content: NavigationBarScope.() -> Unit
 ) {
   val scope = remember(content) { NavigationBarScope().apply(content) }
@@ -70,15 +71,22 @@ fun NavigationBar(
 
   Surface(modifier, color = NavigationBarDefaults.ContainerColor, contentColor = Color.White) {
     Column(Modifier.padding(spacing).testTag(NAVIGATION_BAR_TAG), Arrangement.spacedBy(spacing)) {
-      Box(Modifier.fillMaxWidth(), Alignment.Center) {
+      Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
         ProvideTextStyle(
           AutosTheme.typography.headlineLarge.copy(
             color = LocalContentColor.current,
             textAlign = TextAlign.Center
-          )
-        ) {
-          title()
-        }
+          ),
+          title
+        )
+
+        ProvideTextStyle(
+          AutosTheme.typography.titleSmall.copy(
+            color = LocalContentColor.current,
+            textAlign = TextAlign.Center
+          ),
+          subtitle
+        )
       }
 
       Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBar.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBar.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.ProvideTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.orca.platform.autos.iconography.asImageVector
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.BackAction
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.top.text.AutoSizeText
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+import com.jeanbarrossilva.orca.platform.autos.theme.MultiThemePreview
+
+/** Tag that identifies a [NavigationBar] for testing purposes. */
+const val NAVIGATION_BAR_TAG = "navigation-bar"
+
+/** Default values used by a [NavigationBar]. */
+object NavigationBarDefaults {
+  /** [Color] by which the container of a [NavigationBar] is colored. */
+  val ContainerColor = Color.Black
+}
+
+/**
+ * Bar to which tabs for accessing different contexts within Orca can be added and/or a prominent
+ * navigation action (such as going back to a previous context) may be performed.
+ *
+ * @param title [AutoSizeText] that describes the current context.
+ * @param action Main navigation action.
+ * @param modifier [Modifier] to be applied to the underlying [Surface].
+ * @param content Tabs that are shown, configured through the provided [NavigationBarScope].
+ * @see NavigationBarScope.tab
+ */
+@Composable
+fun NavigationBar(
+  title: @Composable () -> Unit,
+  action: @Composable () -> Unit,
+  modifier: Modifier = Modifier,
+  content: NavigationBarScope.() -> Unit
+) {
+  val scope = remember(content) { NavigationBarScope().apply(content) }
+  val spacing = AutosTheme.spacings.medium.dp
+
+  Surface(modifier, color = NavigationBarDefaults.ContainerColor, contentColor = Color.White) {
+    Column(Modifier.padding(spacing).testTag(NAVIGATION_BAR_TAG), Arrangement.spacedBy(spacing)) {
+      Box(Modifier.fillMaxWidth(), Alignment.Center) {
+        ProvideTextStyle(
+          AutosTheme.typography.headlineLarge.copy(
+            color = LocalContentColor.current,
+            textAlign = TextAlign.Center
+          )
+        ) {
+          title()
+        }
+      }
+
+      Row(Modifier.fillMaxWidth(), Arrangement.SpaceBetween) {
+        action()
+        scope.tabs.forEach { it() }
+      }
+    }
+  }
+}
+
+/** Preview of a [NavigationBar]. */
+@Composable
+@MultiThemePreview
+private fun NavigationBarPreview() {
+  AutosTheme {
+    NavigationBar(title = { AutoSizeText("Home") }, action = { BackAction(onClick = {}) }) {
+      tab(onClick = {}) {
+        Icon(AutosTheme.iconography.home.filled.asImageVector, contentDescription = "Home")
+      }
+
+      tab(onClick = {}) {
+        Icon(AutosTheme.iconography.profile.outlined.asImageVector, contentDescription = "Profile")
+      }
+
+      tab(onClick = {}) {
+        Icon(
+          AutosTheme.iconography.settings.outlined.asImageVector,
+          contentDescription = "Settings"
+        )
+      }
+    }
+  }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBarScope.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBarScope.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation
+
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.jeanbarrossilva.orca.platform.autos.kit.action.button.icon.HoverableIconButton
+
+/**
+ * Scope from which tabs can be added to a [NavigationBar].
+ *
+ * @see tab
+ */
+class NavigationBarScope internal constructor() {
+  /** Index of the currently selected tab. */
+  private var selectedTabIndex by mutableIntStateOf(0)
+
+  /** Tabs that have been added. */
+  internal val tabs = mutableStateListOf<@Composable () -> Unit>()
+
+  /**
+   * Adds a selectable navigation tab.
+   *
+   * @param onClick Action performed when the tab is clicked.
+   * @param modifier [Modifier] to be applied to the underlying [HoverableIconButton].
+   * @param content [Icon] to be shown.
+   */
+  fun tab(onClick: () -> Unit, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    tabs.add { HoverableIconButton(onClick, modifier.testTag(TAB_TAG), content) }
+  }
+
+  companion object {
+    /** Tag by which a tab is identified for testing purposes. */
+    const val TAB_TAG = "tab"
+  }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/scope/Content.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/scope/Content.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.scope
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import com.jeanbarrossilva.orca.platform.autos.forms.asShape
+import com.jeanbarrossilva.orca.platform.autos.kit.bottom
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBarScope
+import com.jeanbarrossilva.orca.platform.autos.theme.AutosTheme
+
+/** Defines how a [Composable] containing a specific context should be laid out. */
+abstract class Content internal constructor() {
+  /** [Shape] by which the [Composable] is be shaped. */
+  @get:Composable protected abstract val shape: Shape
+
+  /** [Composable] to be shown. */
+  internal abstract val value: @Composable (padding: PaddingValues) -> Unit
+
+  /** [Content] that is displayed all by itself. */
+  internal class Expanded(override val value: @Composable (padding: PaddingValues) -> Unit) :
+    Content() {
+    override val shape
+      @Composable get() = RectangleShape
+  }
+
+  /**
+   * [Content] that is shown as a result of the selection of a [NavigationBar] tab.
+   *
+   * @see NavigationBarScope.tab
+   */
+  internal class Navigable(override val value: @Composable (padding: PaddingValues) -> Unit) :
+    Content() {
+    override val shape
+      @Composable get() = AutosTheme.forms.medium.asShape.bottom
+  }
+
+  /**
+   * [value] clipped by the specified [shape].
+   *
+   * @param padding [PaddingValues] to be passed into the [value].
+   */
+  @Composable
+  internal fun ClippedValue(padding: PaddingValues) {
+    Box(Modifier.clip(shape)) { value(padding) }
+  }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/scope/ScaffoldScope.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/scope/ScaffoldScope.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2024 Orca
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program. If
+ * not, see https://www.gnu.org/licenses.
+ */
+
+package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.scope
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBar
+import com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation.NavigationBarScope
+
+/** Scope from which the [Content] of a [Scaffold] can be defined. */
+class ScaffoldScope internal constructor() {
+  /**
+   * Creates a [Content] that is displayed all by itself.
+   *
+   * @param value [Composable] to be shown.
+   */
+  fun expanded(value: @Composable (padding: PaddingValues) -> Unit): Content {
+    return Content.Expanded(value)
+  }
+
+  /**
+   * Creates a [Content] that is shown as a result of the selection of a [NavigationBar] tab.
+   *
+   * @param value [Composable] to be shown.
+   * @see NavigationBarScope.tab
+   */
+  fun navigable(value: @Composable (padding: PaddingValues) -> Unit): Content {
+    return Content.Navigable(value)
+  }
+}

--- a/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/sheet/Sheet.kt
+++ b/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/sheet/Sheet.kt
@@ -75,13 +75,15 @@ private fun SheetPreview() {
     @OptIn(ExperimentalMaterial3Api::class)
     Sheet {
       Scaffold(topAppBar = { TopAppBar(title = { AutoSizeText("Title") }) }) {
-        Box(
-          Modifier.clip(AutosTheme.forms.large.asShape)
-            .background(AutosTheme.colors.surface.container.asColor)
-            .fillMaxSize(),
-          Alignment.Center
-        ) {
-          Text("Content", style = AutosTheme.typography.titleMedium)
+        expanded {
+          Box(
+            Modifier.clip(AutosTheme.forms.large.asShape)
+              .background(AutosTheme.colors.surface.container.asColor)
+              .fillMaxSize(),
+            Alignment.Center
+          ) {
+            Text("Content", style = AutosTheme.typography.titleMedium)
+          }
         }
       }
     }

--- a/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBarScopeTests.kt
+++ b/platform/autos/src/test/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/navigation/NavigationBarScopeTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Orca
+ * Copyright © 2024 Orca
  *
  * This program is free software: you can redistribute it and/or modify it under the terms of the
  * GNU General Public License as published by the Free Software Foundation, either version 3 of the
@@ -13,18 +13,16 @@
  * not, see https://www.gnu.org/licenses.
  */
 
-@file:JvmName("CornerBasedShapes")
+package com.jeanbarrossilva.orca.platform.autos.kit.scaffold.bar.navigation
 
-package com.jeanbarrossilva.orca.platform.autos.kit
+import assertk.assertThat
+import assertk.assertions.hasSize
+import kotlin.test.Test
 
-import androidx.compose.foundation.shape.CornerBasedShape
-import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.foundation.shape.ZeroCornerSize
-
-/** Version of this [CornerBasedShape] with zeroed top [CornerSize]s. */
-internal val CornerBasedShape.bottom
-  get() = copy(topStart = ZeroCornerSize, topEnd = ZeroCornerSize)
-
-/** Version of this [CornerBasedShape] with zeroed bottom [CornerSize]s. */
-internal val CornerBasedShape.top
-  get() = copy(bottomEnd = ZeroCornerSize, bottomStart = ZeroCornerSize)
+internal class NavigationBarScopeTests {
+  @Test
+  fun addsTab() {
+    val scope = NavigationBarScope().apply { tab(onClick = {}) {} }
+    assertThat(scope.tabs).hasSize(1)
+  }
+}


### PR DESCRIPTION
Adds a bar for navigation to be added to the [`Scaffold`](https://github.com/orcaformastodon/android/blob/9d92540aa6d7455efbf728b215cb4f7ddccb34b9/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/Scaffold.kt), posteriorly replacing both the [top app bar](https://github.com/orcaformastodon/android/tree/9d92540aa6d7455efbf728b215cb4f7ddccb34b9/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/top) and the [`OrcaBottomNavigationView`](https://github.com/orcaformastodon/android/blob/9d92540aa6d7455efbf728b215cb4f7ddccb34b9/platform/autos/src/main/java/com/jeanbarrossilva/orca/platform/autos/kit/scaffold/bar/bottom/OrcaBottomNavigationView.java).

<img src="https://github.com/orcaformastodon/android/assets/38408390/053e1e19-2dee-4843-ad66-0895fadc9f42" width="512" />
